### PR TITLE
Switch completely to an HTTPS CDN for leaflet

### DIFF
--- a/examples/GeoJSON.ipynb
+++ b/examples/GeoJSON.ipynb
@@ -50,7 +50,7 @@
      "outputs": [
       {
        "html": [
-        "<link rel=\"stylesheet\" href=\"//cdn.leafletjs.com/leaflet-0.7.2/leaflet.css\" />"
+        "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.css\" />"
        ],
        "metadata": {},
        "output_type": "display_data",
@@ -60,7 +60,7 @@
       },
       {
        "html": [
-        "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw.css\" />"
+        "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw.css\" />"
        ],
        "metadata": {},
        "output_type": "display_data",
@@ -74,8 +74,8 @@
         "\n",
         "require.config({\n",
         "    paths: {\n",
-        "        leaflet: \"http://cdn.leafletjs.com/leaflet-0.7.2/leaflet\",\n",
-        "        leaflet_draw: \"http://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw\"\n",
+        "        leaflet: \"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet\",\n",
+        "        leaflet_draw: \"https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw\"\n",
         "    },\n",
         "    shim: {leaflet_draw: \"leaflet\"}\n",
         "});\n",

--- a/examples/MapContainer.ipynb
+++ b/examples/MapContainer.ipynb
@@ -50,7 +50,7 @@
      "outputs": [
       {
        "html": [
-        "<link rel=\"stylesheet\" href=\"//cdn.leafletjs.com/leaflet-0.7.2/leaflet.css\" />"
+        "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.css\" />"
        ],
        "metadata": {},
        "output_type": "display_data",
@@ -60,7 +60,7 @@
       },
       {
        "html": [
-        "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw.css\" />"
+        "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw.css\" />"
        ],
        "metadata": {},
        "output_type": "display_data",
@@ -74,8 +74,8 @@
         "\n",
         "require.config({\n",
         "    paths: {\n",
-        "        leaflet: \"http://cdn.leafletjs.com/leaflet-0.7.2/leaflet\",\n",
-        "        leaflet_draw: \"http://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw\"\n",
+        "        leaflet: \"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet\",\n",
+        "        leaflet_draw: \"https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw\"\n",
         "    },\n",
         "    shim: {leaflet_draw: \"leaflet\"}\n",
         "});\n",

--- a/install-nbextension.py
+++ b/install-nbextension.py
@@ -28,8 +28,8 @@ def install_files(url, dir, files):
             f.write(r.content)
 
 
-leaflet_url = 'http://cdn.leafletjs.com'
-leaflet_dir = 'leaflet-0.7.2'
+leaflet_url = 'https://cdnjs.cloudflare.com'
+leaflet_dir = 'ajax/libs/leaflet/0.7.2'
 leaflet_files = [
     ['leaflet.css',],
     ['leaflet.js',],
@@ -39,7 +39,7 @@ leaflet_files = [
 
 install_files(leaflet_url, leaflet_dir, leaflet_files)
 
-leaflet_draw_url = 'http://cdnjs.cloudflare.com/ajax/libs/'
+leaflet_draw_url = 'https://cdnjs.cloudflare.com/ajax/libs/'
 leaflet_draw_dir = 'leaflet.draw/0.2.3'
 leaflet_draw_files = [
     ['leaflet.draw.css',],

--- a/leafletwidget/notebook.py
+++ b/leafletwidget/notebook.py
@@ -8,9 +8,9 @@ from IPython.display import display, HTML, Javascript
 leaflet_css = 'leaflet.css'
 # leaflet_url = '/nbextensions/leaflet-0.7.2'
 leaflet_js = 'leaflet'
-leaflet_url = '//cdn.leafletjs.com/leaflet-0.7.2'
+leaflet_url = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/'
 
-leaflet_draw_url = '//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3'
+leaflet_draw_url = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3'
 # leaflet_draw_url = '/nbextensions/leaflet.draw/0.2.3'
 leaflet_draw_css = 'leaflet.draw.css'
 leaflet_draw_js = 'leaflet.draw'


### PR DESCRIPTION
Like it says. I've switched all references to the HTTP CDN on leaflet and the relative scheme to using HTTPS on https://cdnjs.cloudflare.com.
