### PR TITLE
forward changes in url and opacity to leaflet

### DIFF
--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -104,7 +104,20 @@ var LeafletImageOverlayView = LeafletRasterLayerView.extend({
             this.model.get('bounds'),
             this.get_options()
         );
+        this._forward_changes('url')
+        this._forward_changes('opacity')
     },
+    _forward_changes: function(key) {
+        // listen to a changes in 'some_property' and on change call this.obj.setSomeProperty(value)
+        // where obj is the leaflet object
+        this.listenTo(this.model, 'change:' + key, function () {
+            var setterName = camel_case('set_' + key);
+            var setter = this.obj[setterName];
+            if(setter) {
+                setter.apply(this.obj, [this.model.get(key)])
+            }
+        }, this);
+    }
 });
 
 


### PR DESCRIPTION
This will cause any changes in ImageOverlay's url and opacity properties to be forwarded to leaflet. Before, if you changed the url or opacity from the Python or backbone model side, nothing would happen. 
The code is quite general, and can be applied to other properties as well in the future.
In need this since I'm using ipyleaflet as one of the backends for [vaex](http://vaex.astro.rug.nl) where I overlay for instance the new york taxi dataset. I'd like to change the opacity, and more efficiently go through layers of the data.