### PR TITLE
Fix issue with CircleMarker radius

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -437,14 +437,14 @@ class CircleMarker(Path):
     _model_name = Unicode('LeafletCircleMarkerModel').tag(sync=True)
 
     location = List(def_loc).tag(sync=True)
-    radius = Int(10, help="radius of circle in pixels").tag(sync=True)
+    radius = Int(10, help="radius of circle in pixels").tag(sync=True, o=True)
 
 
 class Circle(CircleMarker):
     _view_name = Unicode('LeafletCircleView').tag(sync=True)
     _model_name = Unicode('LeafletCircleModel').tag(sync=True)
 
-    radius = Int(1000, help="radius of circle in meters").tag(sync=True)
+    radius = Int(1000, help="radius of circle in meters").tag(sync=True, o=True)
 
 
 class MarkerCluster(Layer):

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -331,6 +331,15 @@ var LeafletCircleView = LeafletCircleMarkerView.extend({
             this.model.get('location'), this.get_options()
         );
     },
+
+    model_events: function () {
+        LeafletCircleView.__super__.model_events.apply(this, arguments);
+
+        // Workaround for https://github.com/Leaflet/Leaflet/pull/6128
+        this.listenTo(this.model, 'change:radius', function () {
+            this.obj.setRadius(this.get_options().radius);
+        }, this);
+    },
 });
 
 

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -312,8 +312,7 @@ var LeafletRectangleView = LeafletPolygonView.extend({
 var LeafletCircleMarkerView = LeafletPathView.extend({
     create_obj: function () {
         this.obj = L.circleMarker(
-            this.model.get('location'), this.model.get('radius'),
-            this.get_options()
+            this.model.get('location'), this.get_options()
         );
     },
 
@@ -329,8 +328,7 @@ var LeafletCircleMarkerView = LeafletPathView.extend({
 var LeafletCircleView = LeafletCircleMarkerView.extend({
     create_obj: function () {
         this.obj = L.circle(
-            this.model.get('location'), this.model.get('radius'),
-            this.get_options()
+            this.model.get('location'), this.get_options()
         );
     },
 });
@@ -990,8 +988,7 @@ var LeafletCircleMarkerModel = LeafletPathModel.extend({
     defaults: _.extend({}, LeafletPathModel.prototype.defaults, {
         _view_name : 'LeafletCircleMarkerView',
         _model_name : 'LeafletCircleMarkerModel',
-        location : def_loc,
-        radius : 10
+        location : def_loc
     })
 });
 
@@ -999,8 +996,7 @@ var LeafletCircleMarkerModel = LeafletPathModel.extend({
 var LeafletCircleModel = LeafletCircleMarkerModel.extend({
     defaults: _.extend({}, LeafletCircleMarkerModel.prototype.defaults, {
         _view_name : 'LeafletCircleView',
-        _model_name : 'LeafletCircleModel',
-        radius : 10000
+        _model_name : 'LeafletCircleModel'
     })
 });
 


### PR DESCRIPTION
Radius attribute is now an option for CircleMarker and Circle classes. Fixing the update of the radius for CircleMarker. I did the same changes for the Circle class, but it still doesn't work because of an issue in Leaflet: https://github.com/Leaflet/Leaflet/pull/6128 