### PR TITLE
Remove useless clickable attribute of Marker class

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -85,7 +85,6 @@ class Marker(UILayer):
     location = List(def_loc).tag(sync=True)
     z_index_offset = Int().tag(sync=True, o=True)
     # write
-    clickable = Bool(True).tag(sync=True, o=True)
     draggable = Bool(True).tag(sync=True, o=True)
     keyboard = Bool(True).tag(sync=True, o=True)
     title = Unicode().tag(sync=True, o=True)

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -978,7 +978,6 @@ var LeafletMarkerModel = LeafletUILayerModel.extend({
         _model_name : 'LeafletMarkerModel',
         location : def_loc,
         z_index_offset: 0,
-        clickable: true,
         draggable: true,
         keyboard: true,
         title: '',
@@ -1092,7 +1091,6 @@ var LeafletPathModel = LeafletVectorLayerModel.extend({
         dash_array : '',
         line_cap : '',
         line_join :  '',
-        clickable : true,
         pointer_events : '',
         class_name : ''
     })


### PR DESCRIPTION
It seems like the `clickable` attribute of `Marker` class is useless. It's never used on the javascript side, and not part of the options in Leaflet: https://github.com/Leaflet/Leaflet/blob/master/src/layer/marker/Marker.js