### PR TITLE
Adding documentation about getting jupyterlab ipyleaflet working

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Some users have found that the ``jupyterlab-manager`` is also required
 in jupyterlab if the map does not display.
 
 ```
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
+$ jupyter labextension install @jupyter-widgets/jupyterlab-manager
 ```
 
 ## Installation from sources

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ If you have JupyterLab, you will also need to install the JupyterLab extension:
 $ jupyter labextension install jupyter-leaflet
 ```
 
+Some users have found that the ``jupyterlab-manager`` is also required
+in jupyterlab if the map does not display.
+
+```
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+```
+
 ## Installation from sources
 
 For a development installation (requires npm):

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -24,6 +24,17 @@ If you have JupyterLab, you will also need to install the JupyterLab extension:
 
     jupyter labextension install jupyter-leaflet
 
+Some users have found that the ``jupyterlab-manager`` is also required
+if the map does not display. See `issue 173
+<https://github.com/jupyter-widgets/ipyleaflet/issues/173>`_ and
+`issue 168
+<https://github.com/jupyter-widgets/ipyleaflet/issues/168>`_ for
+details.
+
+.. code:: bash
+
+   jupyter labextension install @jupyter-widgets/jupyterlab-manager
+
 Development installation
 ========================
 


### PR DESCRIPTION
I ran into an issue that ipyleaflet would only display in `jupyter
notebooks` and not `jupyter lab`. This details the additional step
needed to get it working on Jupyterlab.

This addresses these two issues #168  and #173 