### PR TITLE
Switch to jupyterlab for binder examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ipyleaflet
 
 [![Documentation](http://readthedocs.org/projects/ipyleaflet/badge/?version=latest)](https://ipyleaflet.readthedocs.io/en/latest/?badge=latest)
-[![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](http://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/0.8.4?urlpath=lab/tree/examples)
+[![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/0.8.4?filepath=examples)
 [![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter-widgets/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A Jupyter / Leaflet bridge enabling interactive maps in the Jupyter notebook.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ipyleaflet
 
 [![Documentation](http://readthedocs.org/projects/ipyleaflet/badge/?version=latest)](https://ipyleaflet.readthedocs.io/en/latest/?badge=latest)
-[![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/0.8.4?filepath=examples)
+[![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](http://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/0.8.4?urlpath=lab/tree/examples)
 [![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter-widgets/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A Jupyter / Leaflet bridge enabling interactive maps in the Jupyter notebook.

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyter-leaflet

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34.0
 jupyter labextension install jupyter-leaflet


### PR DESCRIPTION
I previously submitted a pull request for improving the documentation on using ipyleaflet with jupyterlab. In fact I needed it to work for a binder example project of my own. So I wanted to offer a minimal pull request that will set the default binder launch button to use jupyterlab instead of jupyter notebooks. 

The only addition required is a [postBuild](https://mybinder.readthedocs.io/en/latest/using.html#postbuild) file for adding the two labextensions: jupyter-manager and ipyleaflet.  Description of what a postBuild file is [here](https://mybinder.readthedocs.io/en/latest/using.html#postbuild)

You may use the following link to test of the binder jupyterlab notebook examples before the pull request. I have already tested that all the example notebooks run and display properly in binder before the request.

https://mybinder.org/v2/gh/costrouc/ipyleaflet/costrouc/binder-jupyterlab?urlpath=lab%2Ftree%2Fexamples

