### PR TITLE
Xarray no longer supports python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup_args = {
     'install_requires': [
         'ipywidgets>=7.0.0,<8',
         'traittypes>=0.2.1,<3',
-        'xarray>=0.10,<0.11',
+        'xarray>=0.10,<0.10.8',
         ],
     'packages': find_packages(),
     'zip_safe': False,


### PR DESCRIPTION
Since 0.10.8 xarray no longer supports python 3.4, see this [commit](https://github.com/drnextgis/xarray/commit/1688a59803786a9d88eeb43aa4c935f7052d6a80#diff-2eeaed663bd0d25b7e608891384b7298).