### PR TITLE
Changes for NASA GIBS sample imagery endpoints.

### DIFF
--- a/docs/source/api_reference/embed_widgets/layers_control.html
+++ b/docs/source/api_reference/embed_widgets/layers_control.html
@@ -118,7 +118,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2018-03-30/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "e2cc217055b9406abb808c51cc947fc1": {

--- a/docs/source/api_reference/embed_widgets/map.html
+++ b/docs/source/api_reference/embed_widgets/map.html
@@ -24,7 +24,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2018-04-08/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "199eb350da6c44de875b5336a7b18bdb": {
@@ -270,7 +270,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2018-04-08/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "62d45e65667e4f1e97c62bcd6d4bb1f4": {
@@ -512,7 +512,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2018-04-08/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "f5bb3f8c052d4ba08331ab2347ff208f": {
@@ -567,7 +567,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2017-04-08/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "ab2369332a024dda83800361d0a1343e": {

--- a/docs/source/api_reference/embed_widgets/split_map_control.html
+++ b/docs/source/api_reference/embed_widgets/split_map_control.html
@@ -144,7 +144,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/2017-11-11/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "4ac22e22776e4f678a617e97851c778b": {
@@ -174,7 +174,7 @@
                 "attribution",
                 "detect_retina"
             ],
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Aqua_CorrectedReflectance_Bands721/default/2017-11-11/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/2019-01-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
         }
     },
     "84a72c3673894293abd4ccd52bef49d8": {

--- a/ipyleaflet/basemaps.py
+++ b/ipyleaflet/basemaps.py
@@ -143,40 +143,46 @@ basemaps = Bunch(
     ),
     NASAGIBS = Bunch(
         ModisTerraTrueColorCR = dict(
-            url = 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom = 9,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
             name = 'NASAGIBS.ModisTerraTrueColorCR'
         ),
         ModisTerraBands367CR = dict(
-            url = 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_Bands367/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands367/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom = 9,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
             name = 'NASAGIBS.ModisTerraBands367CR'
         ),
         ModisTerraBands721CR = dict(
-            url = 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_Bands721/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom = 9,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
             name = 'NASAGIBS.MidsTerraBands721CR'
         ),
         ModisAquaTrueColorCR = dict(
-            url = 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Aqua_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom = 9,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
             name = 'NASAGIBS.ModisAquaTrueColorCR'
         ),
         ModisAquaBands721CR = dict(
-            url = 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Aqua_CorrectedReflectance_Bands721/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom = 9,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
             name = 'NASAGIBS.ModisAquaBands721CR'
         ),
+        ViirsTrueColorCR = dict(
+            url = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
+            max_zoom = 9,
+            attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
+            name = 'NASAGIBS.ViirsTrueColorCR'
+        ),
         ViirsEarthAtNight2012 = dict(
-            url = 'http://map1.vis.earthdata.nasa.gov/wmts-webmerc/VIIRS_CityLights_2012/default/2012-08-01/GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpg',
+            url = 'http://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_Black_Marble/default/2012-01-01/GoogleMapsCompatible_Level8/{z}/{y}/{x}.png',
             max_zoom = 8,
             attribution = 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
-            name = 'BASAGIBS.ViirsEarthAtNight2012'
+            name = 'NASAGIBS.ViirsEarthAtNight2012'
         )
     ),
     Strava = Bunch(


### PR DESCRIPTION
- Updating GIBS URLs to use the offical endpoints and a more recent date.
- Adding VIIRS True Color Corrected Reflectance.
- Updating VIIRS Earth at Night to use the newer layer.  Technically "Black Marble", but still the earth at night.