### PR TITLE
Remove useless code

### DIFF
--- a/js/src/controls/LayersControl.js
+++ b/js/src/controls/LayersControl.js
@@ -61,8 +61,6 @@ var LeafletLayersControlView = LeafletControlView.extend({
             }, {});
             that.obj = L.control.layers(baselayers, overlays);
             return that;
-        }).then(function() {
-            that.obj.addTo(that.map_view.obj);
         });
     }
 });

--- a/js/src/controls/MeasureControl.js
+++ b/js/src/controls/MeasureControl.js
@@ -39,7 +39,6 @@ var LeafletMeasureControlView = LeafletControlView.extend({
 
     create_obj: function () {
         this.obj = L.control.measure(this.get_options());
-        this.obj.addTo(this.map_view.obj);
         this.default_units = L.extend({}, this.obj.options.units);
     },
 


### PR DESCRIPTION
Controls are added to the Map by the Map itself already. No need to add it from
the control implementation.