### PR TITLE
Load Leaflet in no-conflict mode if L is already defined

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -13,5 +13,11 @@ require('leaflet/dist/images/marker-icon.png');
 require('leaflet/dist/images/marker-icon-2x.png');
 
 // Export everything from jupyter-leaflet and the npm package version number.
+hasL = (typeof(window.L) != 'undefined');
 module.exports = require('./jupyter-leaflet.js');
 module.exports['version'] = require('../package.json').version;
+
+if (hasL) {
+    ipyL = L.noConflict();
+}
+

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -18,6 +18,7 @@ module.exports = require('./jupyter-leaflet.js');
 module.exports['version'] = require('../package.json').version;
 
 if (hasL) {
+    console.log("Existing `L` detected, running ipyleaflet's Leaflet in no-conflict mode as `ipyL`");
     ipyL = L.noConflict();
 }
 

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -20,10 +20,4 @@ L.Icon.Default.mergeOptions({
     shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
 });
 
-if (typeof(L) == 'undefined') {
-    module.exports = L;
-} else {
-    console.log("Existing Leaflet detected in globals as `L`- using `ipyL` for ipyleaflet's reference");
-    ipyL = L.noConflict()    
-    module.exports = ipyL;
-}
+module.exports = L;

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -20,4 +20,10 @@ L.Icon.Default.mergeOptions({
     shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
 });
 
-module.exports = L;
+if (typeof(L) == 'undefined') {
+    module.exports = L;
+} else {
+    console.log("Existing Leaflet detected in globals as `L`- using `ipyL` for ipyleaflet's reference");
+    ipyL = L.noConflict()    
+    module.exports = ipyL;
+}


### PR DESCRIPTION
Leaflet has a no-conflict mode where if `L` is already defined, it can be restored as `window.L` with Leaflet assigned to another variable of choice.

In this specific case, if another Jupyter widget is already trying to use it's own version of Leaflet, loading ipyleaflet will redefine the existing Leaflet library, and any control or plugins that were previously loaded into the first Leaflet namespace will disappear.

This fix checks to see if `L` is already defined, and if it is, it uses `Leaflet.noConflict()` to restore the previous `L` and moves ipyleaflet's Leaflet to the variable `ipyL`.

Users who only use ipyleaflet will not be impacted as Leaflet will load as `L` in the standard manner.