### PR TITLE
removed xarray upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup_args = {
     'install_requires': [
         'ipywidgets>=7.0.0,<8',
         'traittypes>=0.2.1,<3',
-        'xarray>=0.10,<0.10.8',
+        'xarray>=0.10',
         'branca>=0.3.1,<0.4'
         ],
     'packages': find_packages(),


### PR DESCRIPTION
a simple change to allow newer versions of xarray to be installed alongside ipyleaflet. Related issues: https://github.com/jupyter-widgets/ipyleaflet/issues/297, https://github.com/jupyter-widgets/ipyleaflet/pull/221, https://github.com/jupyter-widgets/ipyleaflet/issues/212 