### PR TITLE
Bump jupyterlab-manager to 0.38

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34.0
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.38
 jupyter labextension install jupyter-leaflet


### PR DESCRIPTION
Binder images currently use JupyterLab 0.35 by default.
The compatible version for `@jupyter-widgets/jupyterlab-manager` is 0.38.