### PR TITLE
Use JLab background color for widget controls

### DIFF
--- a/js/src/jupyter-leaflet.css
+++ b/js/src/jupyter-leaflet.css
@@ -5,7 +5,7 @@
 }
 
 .leaflet-widgetcontrol {
-    background-color: #ffffff;
+    background: var(--jp-layout-color1);
     border-radius: 4.5px;
     box-shadow: 4px 5px 8px 0px #9e9e9e
 }


### PR DESCRIPTION
A small / simple change to fix the following glitch when using the JupyterLab Dark theme:

### Before

![image](https://user-images.githubusercontent.com/591645/55748487-1dbee500-5a3f-11e9-8e1d-03bc35bf0b90.png)


### After

![image](https://user-images.githubusercontent.com/591645/55748450-fff18000-5a3e-11e9-93b9-8357dc63b60e.png)

In the context of the classic notebook, the background will default to the original `#ffffff` value.