### PR TITLE
Change name of OpenTopoMap from 'OpenTopMap' to 'OpenTopoMap'

### DIFF
--- a/ipyleaflet/basemaps.py
+++ b/ipyleaflet/basemaps.py
@@ -85,7 +85,7 @@ basemaps = Bunch(
             url = 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
             max_zoom = 20,
             attribution = 'Tiles &copy; Esri &mdash; Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012',
-            name = 'Esri.WoldStreetMap'
+            name = 'Esri.WorldStreetMap'
         ),
         DeLorme = dict(
             url = 'http://server.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer/tile/{z}/{y}/{x}',

--- a/ipyleaflet/basemaps.py
+++ b/ipyleaflet/basemaps.py
@@ -50,7 +50,7 @@ basemaps = Bunch(
         url = 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
         max_zoom = 17,
         attribution = 'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
-        name = 'OpenTopMap'
+        name = 'OpenTopoMap'
     ),
     OpenMapSurfer = Bunch(
         Roads = dict(


### PR DESCRIPTION
I think that this was a typo given that OpenTopoMap is called using ```basemaps.OpenTopoMap```