### PR TITLE
Fix styling problems for GeoJSON

### DIFF
--- a/js/src/layers/GeoJSON.js
+++ b/js/src/layers/GeoJSON.js
@@ -16,9 +16,9 @@ var LeafletGeoJSONModel = featuregroup.LeafletFeatureGroupModel.extend({
 var LeafletGeoJSONView = featuregroup.LeafletFeatureGroupView.extend({
     create_obj: function () {
         var that = this;
-        var model_style = this.model.get('style');
         style = function (feature) {
-            return _.extend(feature.properties.style, model_style);
+            var model_style = that.model.get('style');
+            return _.extend(feature.properties.style || {}, model_style);
         }
         this.obj = L.geoJson(this.model.get('data'), {
             style: style,


### PR DESCRIPTION
### GeoJSON style issue

There were two problems:

1. `_.extend(undefined, {..})` is `undefined`, so style would not apply to geojson objects without style defined.
2. New style would revert to original after every hover, since initial style was captured at
   construction and was never updated.

This addresses issue #341.