### PR TITLE
Expose fullscreen control/state

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -815,6 +815,7 @@ class Map(DOMWidget, InteractMixin):
     # zoom_animation = Bool(?).tag(sync=True, o=True)
     zoom_animation_threshold = Int(4).tag(sync=True, o=True)
     # marker_zoom_animation = Bool(?).tag(sync=True, o=True)
+    fullscreen = Bool(False).tag(sync=True, o=True)
 
     options = List(trait=Unicode).tag(sync=True)
 

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -241,6 +241,9 @@ var LeafletMapView = utils.LeafletDOMWidgetView.extend({
                 location: that.model.get('location')
             });
         });
+        this.obj.on('fullscreenchange', function() {
+            that.model.set('fullscreen', that.obj.isFullscreen());
+        });
     },
     model_events: function () {
         var that = this;
@@ -288,6 +291,12 @@ var LeafletMapView = utils.LeafletDOMWidgetView.extend({
         }, this);
         this.listenTo(this.model, 'change:default_style', function () {
             this.model.update_style();
+        }, this);
+        this.listenTo(this.model, 'change:fullscreen', function () {
+            var fullscreen = this.model.get('fullscreen');
+            if (this.obj.isFullscreen() !== fullscreen) {
+                this.obj.toggleFullscreen();
+            }
         }, this);
     },
 


### PR DESCRIPTION
Adding a two way `fullscreen` parameter, setting it to `True` puts map in to
full screen mode, and setting it to `False` exits full screen mode. Current
state is observable via this parameter as well.

## Browser Support

Typically browser will not allow to enter full screen if the event has not
been triggered by the user, so this can only be used in response to the user
action like a button click.

## Safari on macOS

Entering fullscreen mode via custom ui click doesn't work, looks like
safari expects fullscreen request and UI interaction that triggers it to happen
in the same animation frame and not just in "close enough in time". Observing
fullscreen state and exiting it does work however. And it's an important use
case, for example if user completes some input in full screen mode it might be
desirable to exit fullscreen at that point.

## Sample Notebook for testing

```python
import ipyleaflet as L
from ipywidgets import widgets as w

m = L.Map(zoom=2, layout=w.Layout(
    width="200px",
    height="200px",
))

btn = w.Button(description='Enter')
btn.layout.width = '6em'
m.add_control(L.WidgetControl(widget=btn, position='topright'))
m.add_control(L.FullScreenControl())

def on_btn_clk(btn):
    m.fullscreen = not m.fullscreen
    txt = 'Exit' if m.fullscreen else 'Enter'
    btn.description = txt

def on_fullscreen_change(e):
    txt = 'Exit' if e['new'] else 'Enter'
    btn.description = txt

m.observe(on_fullscreen_change, ['fullscreen'])
btn.on_click(on_btn_clk)
m
```