### PR TITLE
Add no_wrap option for TileLayer

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -234,7 +234,8 @@ class TileLayer(RasterLayer):
     tile_size = Int(256).tag(sync=True, o=True)
     attribution = Unicode('Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors').tag(sync=True, o=True)
     detect_retina = Bool(False).tag(sync=True, o=True)
-
+    no_wrap = Bool(False).tag(sync=True, o=True)
+    
     _load_callbacks = Instance(CallbackDispatcher, ())
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This add the [noWrap](https://leafletjs.com/reference-1.5.0.html#gridlayer-nowrap) option for the TileLayer.

Whether the layer is wrapped around the antimeridian. If true, the TileLayer will only be displayed once at low zoom levels.