### PR TITLE
Add workaround for box containers in WidgetControl

### DIFF
--- a/js/src/controls/WidgetControl.js
+++ b/js/src/controls/WidgetControl.js
@@ -77,7 +77,19 @@ var LeafletWidgetControlView = LeafletControlView.extend({
                 // Trigger the displayed event of the child view.
                 this.displayed.then(() => {
                     this.widget_view.trigger('displayed', this);
+
                     this.widget_view.displayed.then(() => {
+                        // Workaround for box containers
+                        if (widget_model.get('children')) {
+                            _.each(widget_model.get('children'), (child) => {
+                                _.each(child.views, (view_promise) => {
+                                    view_promise.then((view) => {
+                                        view.trigger('displayed', this);
+                                    });
+                                });
+                            });
+                        }
+
                         this.updateLayout();
                         this.obj.setContent(view.el);
                     });


### PR DESCRIPTION
This is a workaround for #356. 

WidgetControl contains a widget, if this widget also contains children (e.g VBox, GridBox) it appears that we need to trigger the 'displayed' event on them.

@SylvainCorlay and @jasongrout do you know why we need a `trigger('displayed', this)` on the child container in the first place? We do it [here](https://github.com/jupyter-widgets/ipyleaflet/blob/master/js/src/controls/WidgetControl.js#L79), **it appears that Layout properties are not added if we don't trigger the 'displayed' event**.

What I don't understand is that the 'displayed' event is not triggered in the [BoxView implementation in ipywidgets](https://github.com/jupyter-widgets/ipywidgets/blob/446d60864b3ef9e4615410aedf1dd59735736f52/packages/controls/src/widget_box.ts#L171).

This is the result of [this example](https://github.com/jupyter-widgets/ipyleaflet/issues/356#issue-440713999) without this fix:
![widgetcontrol_before](https://user-images.githubusercontent.com/21197331/57909733-e9cbb080-7883-11e9-8a20-353193d75256.png)

And here is the expected result (with this fix):
![widgetcontrol_fixed](https://user-images.githubusercontent.com/21197331/57909765-fe0fad80-7883-11e9-85a8-05d20cceca02.png)


**Note:** We should have the same issue with the current Popup implementation