### PR TITLE
Add ZoomControl has an Ipyleaflet.Control

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -855,7 +855,7 @@ class Map(DOMWidget, InteractMixin):
     default_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     dragging_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
 
-    zoom_control = Bool(True).tag(sync=True)
+    zoom_control = Bool(False)
 
     @default('dragging_style')
     def _default_dragging_style(self):
@@ -892,6 +892,9 @@ class Map(DOMWidget, InteractMixin):
         super(Map, self).__init__(**kwargs)
         self.on_displayed(self._fire_children_displayed)
         self.on_msg(self._handle_leaflet_event)
+
+        if zoom_control:
+            self.add_control(ZoomControl())
 
     def _fire_children_displayed(self, widget, **kwargs):
         for layer in self.layers:

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -842,7 +842,6 @@ class Map(DOMWidget, InteractMixin):
     inertia_deceleration = Int(3000).tag(sync=True, o=True)
     inertia_max_speed = Int(1500).tag(sync=True, o=True)
     # inertia_threshold = Int(?, o=True).tag(sync=True)
-    zoom_control = Bool(True).tag(sync=True, o=True)
     attribution_control = Bool(True).tag(sync=True, o=True)
     # fade_animation = Bool(?).tag(sync=True, o=True)
     # zoom_animation = Bool(?).tag(sync=True, o=True)
@@ -855,6 +854,8 @@ class Map(DOMWidget, InteractMixin):
     style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     default_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     dragging_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
+
+    zoom_control = Bool(True).tag(sync=True)
 
     @default('dragging_style')
     def _default_dragging_style(self):

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -893,7 +893,7 @@ class Map(DOMWidget, InteractMixin):
         self.on_displayed(self._fire_children_displayed)
         self.on_msg(self._handle_leaflet_event)
 
-        if zoom_control:
+        if self.zoom_control:
             self.add_control(ZoomControl())
 
     def _fire_children_displayed(self, widget, **kwargs):

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -782,10 +782,10 @@ class ZoomControl(Control):
     _view_name = Unicode('LeafletZoomControlView').tag(sync=True)
     _model_name = Unicode('LeafletZoomControlModel').tag(sync=True)
 
-    zoom_in_text = Unicode('+').tag(sync=True)
-    zoom_in_title = Unicode('Zoom in').tag(sync=True)
-    zoom_out_text = Unicode('-').tag(sync=True)
-    zoom_out_title = Unicode('Zoom out').tag(sync=True)
+    zoom_in_text = Unicode('+').tag(sync=True, o=True)
+    zoom_in_title = Unicode('Zoom in').tag(sync=True, o=True)
+    zoom_out_text = Unicode('-').tag(sync=True, o=True)
+    zoom_out_title = Unicode('Zoom out').tag(sync=True, o=True)
 
 
 class MapStyle(Style, Widget):

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -848,14 +848,15 @@ class Map(DOMWidget, InteractMixin):
     zoom_animation_threshold = Int(4).tag(sync=True, o=True)
     # marker_zoom_animation = Bool(?).tag(sync=True, o=True)
     fullscreen = Bool(False).tag(sync=True, o=True)
-    zoom_control = Bool(True)
 
     options = List(trait=Unicode).tag(sync=True)
 
     style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     default_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     dragging_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
-
+    
+    zoom_control = Bool(True)
+    zoom_control_instance = ZoomControl()
 
     @default('dragging_style')
     def _default_dragging_style(self):
@@ -896,11 +897,10 @@ class Map(DOMWidget, InteractMixin):
     @observe('zoom_control')
     def observe_zoom_control(self, change):
         if change['new']:
-            self.add_control(ZoomControl())
+            self.add_control(self.zoom_control_instance)
         else:
-            for control in self.controls:
-                if isinstance(control, ZoomControl):
-                    self.remove_control(control)   
+            if self.zoom_control_instance in self.controls:
+                self.remove_control(self.zoom_control_instance)
 
     def _fire_children_displayed(self, widget, **kwargs):
         for layer in self.layers:

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -848,14 +848,14 @@ class Map(DOMWidget, InteractMixin):
     zoom_animation_threshold = Int(4).tag(sync=True, o=True)
     # marker_zoom_animation = Bool(?).tag(sync=True, o=True)
     fullscreen = Bool(False).tag(sync=True, o=True)
-
+    zoom_control = Bool(True)
+    
     options = List(trait=Unicode).tag(sync=True)
 
     style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     default_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
     dragging_style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
 
-    zoom_control = Bool(False)
 
     @default('dragging_style')
     def _default_dragging_style(self):
@@ -892,7 +892,7 @@ class Map(DOMWidget, InteractMixin):
         super(Map, self).__init__(**kwargs)
         self.on_displayed(self._fire_children_displayed)
         self.on_msg(self._handle_leaflet_event)
-
+        
         if self.zoom_control:
             self.add_control(ZoomControl())
 

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -849,7 +849,7 @@ class Map(DOMWidget, InteractMixin):
     # marker_zoom_animation = Bool(?).tag(sync=True, o=True)
     fullscreen = Bool(False).tag(sync=True, o=True)
     zoom_control = Bool(True)
-    
+
     options = List(trait=Unicode).tag(sync=True)
 
     style = InstanceDict(MapStyle).tag(sync=True, **widget_serialization)
@@ -893,8 +893,14 @@ class Map(DOMWidget, InteractMixin):
         self.on_displayed(self._fire_children_displayed)
         self.on_msg(self._handle_leaflet_event)
         
-        if self.zoom_control:
+    @observe('zoom_control')
+    def observe_zoom_control(self, change):
+        if change['new']:
             self.add_control(ZoomControl())
+        else:
+            for control in self.controls:
+                if isinstance(control, ZoomControl):
+                    self.remove_control(control)   
 
     def _fire_children_displayed(self, widget, **kwargs):
         for layer in self.layers:

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -778,6 +778,16 @@ class DrawControl(Control):
         self.send({'msg': 'clear_markers'})
 
 
+class ZoomControl(Control):
+    _view_name = Unicode('LeafletZoomControlView').tag(sync=True)
+    _model_name = Unicode('LeafletZoomControlModel').tag(sync=True)
+
+    zoom_in_text = Unicode('+').tag(sync=True)
+    zoom_in_title = Unicode('Zoom in').tag(sync=True)
+    zoom_out_text = Unicode('-').tag(sync=True)
+    zoom_out_title = Unicode('Zoom out').tag(sync=True)
+
+
 class MapStyle(Style, Widget):
     """ Map Style Widget """
     _model_name = Unicode('LeafletMapStyleModel').tag(sync=True)

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -197,10 +197,15 @@ var LeafletMapView = utils.LeafletDOMWidgetView.extend({
 
     create_obj: function () {
         return this.layoutPromise.then((views) => {
-            options = this.get_options();
-            options['zoom_control'] = false;
+            var options = _.extend(
+                {
+                    crs: L.CRS[this.model.get('crs')],
+                    zoom_control: false
+                }, 
+                this.get_options()
+            );
             
-            this.obj = L.map(this.map_container, _.extend({crs: L.CRS[this.model.get('crs')]}, options));
+            this.obj = L.map(this.map_container, options);
         });
     },
 

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -56,7 +56,6 @@ var LeafletMapModel = widgets.DOMWidgetModel.extend({
         inertia_deceleration : 3000,
         inertia_max_speed : 1500,
         // inertia_threshold : int(?)
-        zoom_control : false,
         attribution_control : true,
         // fade_animation : bool(?),
         // zoom_animation : bool(?),

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -197,7 +197,10 @@ var LeafletMapView = utils.LeafletDOMWidgetView.extend({
 
     create_obj: function () {
         return this.layoutPromise.then((views) => {
-            this.obj = L.map(this.map_container, _.extend({crs: L.CRS[this.model.get('crs')]}, this.get_options()));
+            options = this.get_options();
+            options['zoom_control'] = false;
+            
+            this.obj = L.map(this.map_container, _.extend({crs: L.CRS[this.model.get('crs')]}, options));
         });
     },
 

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -200,7 +200,7 @@ var LeafletMapView = utils.LeafletDOMWidgetView.extend({
             var options = _.extend(
                 {
                     crs: L.CRS[this.model.get('crs')],
-                    zoom_control: false
+                    zoomControl: false
                 }, 
                 this.get_options()
             );

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -56,7 +56,7 @@ var LeafletMapModel = widgets.DOMWidgetModel.extend({
         inertia_deceleration : 3000,
         inertia_max_speed : 1500,
         // inertia_threshold : int(?)
-        zoom_control : true,
+        zoom_control : false,
         attribution_control : true,
         // fade_animation : bool(?),
         // zoom_animation : bool(?),

--- a/js/src/controls/ZoomControl.js
+++ b/js/src/controls/ZoomControl.js
@@ -1,0 +1,35 @@
+var widgets = require('@jupyter-widgets/base');
+var _ = require('underscore');
+var L = require('../leaflet.js');
+var control = require('./Control.js');
+var LeafletControlView = control.LeafletControlView;
+var LeafletControlModel = control.LeafletControlModel;
+
+var LeafletZoomControlModel = LeafletControlModel.extend({
+    defaults: _.extend({}, LeafletControlModel.prototype.defaults, {
+        _view_name: 'LeafletZoomControlView',
+        _model_name: 'LeafletZoomControlModel',
+
+        zoom_in_text: '+',
+        zoom_in_title: 'Zoom in',
+        zoom_out_text: '-',
+        zoom_out_title: 'Zoom out',
+
+    })
+});
+
+var LeafletZoomControlView = LeafletControlView.extend({
+    initialize: function (parameters) {
+        LeafletZoomControlView.__super__.initialize.apply(this, arguments);
+        this.map_view = this.options.map_view;
+    },
+
+    create_obj: function () {
+        this.obj = L.control.zoom(this.get_options());
+    },
+});
+
+module.exports = {
+    LeafletZoomControlView : LeafletZoomControlView,
+    LeafletZoomControlModel : LeafletZoomControlModel,
+};

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -31,6 +31,7 @@ var measurecontrol = require('./controls/MeasureControl.js');
 var drawcontrol = require('./controls/DrawControl.js');
 var fullscreencontrol = require('./controls/FullScreenControl.js');
 var widgetcontrol = require('./controls/WidgetControl.js')
+var zoomcontrol = require('./controls/ZoomControl.js')
 
 //Map
 var map = require('./Map.js');
@@ -85,6 +86,7 @@ module.exports = {
     LeafletSplitMapControlView : splitmapcontrol.LeafletSplitMapControlView,
     LeafletFullScreenControlView : fullscreencontrol.LeafletFullScreenControlView,
     LeafletWidgetControlView : widgetcontrol.LeafletWidgetControlView,
+    LeafletZoomControlView : zoomcontrol.LeafletZoomControlView,
     LeafletMapView : map.LeafletMapView,
 
     // models
@@ -119,6 +121,7 @@ module.exports = {
     LeafletSplitMapControlModel : splitmapcontrol.LeafletSplitMapControlModel,
     LeafletFullScreenControlModel : fullscreencontrol.LeafletFullScreenControlModel,
     LeafletWidgetControlModel : widgetcontrol.LeafletWidgetControlModel,
+    LeafletZoomControlModel : zoomcontrol.LeafletZoomControlModel,
     LeafletMapModel : map.LeafletMapModel,
     LeafletMapStyleModel : map.LeafletMapStyleModel,
 };


### PR DESCRIPTION
The ZoomControl is the zoom control added when you create a map with the option `zoom_control=True`.

The problem was you could not move it on the map.

Now you can do it :
```
import ipyleaflet as lf
m = lf.Map(zoom=1, zoom_control=False) #Deleting the original from the map
control = lf.ZoomControl(position='topright')
m.add_control(control)
m
```