### PR TITLE
Add missing add of the ZoomControl in __init__

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -893,6 +893,9 @@ class Map(DOMWidget, InteractMixin):
         super(Map, self).__init__(**kwargs)
         self.on_displayed(self._fire_children_displayed)
         self.on_msg(self._handle_leaflet_event)
+
+        if self.zoom_control:
+            self.add_control(self.zoom_control_instance)
         
     @observe('zoom_control')
     def observe_zoom_control(self, change):


### PR DESCRIPTION
It's an oversight in the `__init__` method of the class Map. So when the map is created, the ZoomControl too if `zoom_control=True`