### PR TITLE
Load Stamen tiles over HTTPS

### DIFF
--- a/ipyleaflet/basemaps.py
+++ b/ipyleaflet/basemaps.py
@@ -219,7 +219,7 @@ basemaps = Bunch(
     ),
     Stamen = Bunch(
         Terrain = dict(
-            url = 'http://stamen-tiles-a.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+            url = 'https://stamen-tiles-a.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
             attribution = ''.join([
                 'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, ',
                 'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',
@@ -231,7 +231,7 @@ basemaps = Bunch(
             max_zoom = 18
         ),
         Toner = dict(
-            url = 'http://stamen-tiles-a.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+            url = 'https://stamen-tiles-a.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
             attribution = ''.join([
                 'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, ',
                 'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',
@@ -243,7 +243,7 @@ basemaps = Bunch(
             max_zoom = 20
         ),
         Watercolor = dict(
-            url = 'http://stamen-tiles-a.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
+            url = 'https://stamen-tiles-a.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
             attribution = ''.join([
                 'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, ',
                 'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',


### PR DESCRIPTION
This will fix the following warnings when the notebook server is running behind HTTPS but the tiles are served over HTTP:

```
Loading mixed (insecure) display content “http://stamen-tiles-a.a.ssl.fastly.net/terrain/10/533/366.png” on a secure page
```