### PR TITLE
Add keywords to allow for package to be visible in JupyterLab extension manager

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -5,6 +5,12 @@
   "author": "Project Jupyter",
   "license": "MIT",
   "main": "src/index.js",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension",
+    "widgets"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyter-widgets/ipyleaflet.git"


### PR DESCRIPTION
Fixes #404