### PR TITLE
Sync locations

### DIFF
--- a/js/src/layers/Polyline.js
+++ b/js/src/layers/Polyline.js
@@ -23,6 +23,12 @@ var LeafletPolylineView = LeafletPathView.extend({
             this.get_options()
         );
     },
+    model_events: function () {
+        LeafletPolylineView.__super__.model_events.apply(this, arguments);
+        this.listenTo(this.model, 'change:locations', function () {
+            this.obj.setLatLngs(this.model.get('locations'));
+        }, this);
+    },
 });
 
 module.exports = {


### PR DESCRIPTION
For `Polyline` and `Polygon`, `locations` was not synced between Python and JS. This fix allows to do from Python:
```
polygon.locations = ((34.95100201839405, -78.10704956054689),
 (34.95100201839405, -76.78457031250001),
 (34.49897808891371, -76.78457031250001),
 (34.49897808891371, -78.10704956054689))
```
and have it reflected on the map.