### PR TITLE
Add Leaflet.Path.Transform

### DIFF
--- a/examples/Transform.ipynb
+++ b/examples/Transform.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import Map, Polygon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "center = [22.398332241511387, 114.02332305908205]\n",
+    "zoom = 11"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "m = Map(center=center, zoom=zoom)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polygon_coords = [\n",
+    "    [22.403410892712124, 113.97697448730469],\n",
+    "    [22.38373008592495 , 113.98658752441405],\n",
+    "    [22.369126397545887, 114.01268005371094],\n",
+    "    [22.38563480185718 , 114.02778625488281],\n",
+    "    [22.395157990290755, 114.04701232910156],\n",
+    "    [22.413567638369805, 114.06005859375   ],\n",
+    "    [22.432609534876796, 114.06280517578125],\n",
+    "    [22.444668051657157, 114.04838562011717],\n",
+    "    [22.44847578656544 , 114.04289245605469],\n",
+    "    [22.444668051657157, 114.03259277343749],\n",
+    "    [22.447206553211814, 114.01954650878906],\n",
+    "    [22.436417600763114, 113.99620056152344],\n",
+    "    [22.420549970290875, 113.98178100585938]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a polygon that can be transformed (i.e. rotated and scaled) and dragged. You can drag the polygon around, or use the handler to rotate it and to scale it. Note that the transformations are synced accross all the map views."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pg = Polygon(locations=polygon_coords, transform=True, draggable=True)\n",
+    "m += pg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The scaling can be set to be uniform, meaning that it will preserve the height / width ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pg.uniform_scaling = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ability to scale, rotate and drag can be turned off."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pg.scaling = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pg.rotation = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pg.draggable = False"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -392,10 +392,15 @@ class Polyline(Path):
     _model_name = Unicode('LeafletPolylineModel').tag(sync=True)
 
     locations = List().tag(sync=True)
+    scaling = Bool(True).tag(sync=True)
+    rotation = Bool(True).tag(sync=True)
+    uniform_scaling = Bool(False).tag(sync=True)
 
     # Options
     smooth_factor = Float(1.0).tag(sync=True, o=True)
     no_clip = Bool(True).tag(sync=True, o=True)
+    transform = Bool(False).tag(sync=True, o=True)
+    draggable = Bool(False).tag(sync=True, o=True)
 
 
 class Polygon(Polyline):

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2872,6 +2872,16 @@
         "leaflet": ">=0.7.7 <2.0.0"
       }
     },
+    "leaflet-transform": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/leaflet-transform/-/leaflet-transform-1.0.3.tgz",
+      "integrity": "sha512-B4sX0+qEj7F7PDfFMCj7V5RNozkjzyIvi983MRlnFwF3F94JoAN3cyd58rS8v5ETyXEE2SUe1f+rPA3zCCAIPA==",
+      "requires": {
+        "css-img-datauri-stream": "^0.1.5",
+        "cssify": "^0.8.0",
+        "leaflet": ">=0.7.7 <2.0.0"
+      }
+    },
     "leaflet-velocity": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/leaflet-velocity/-/leaflet-velocity-1.2.4.tgz",

--- a/js/package.json
+++ b/js/package.json
@@ -39,6 +39,7 @@
     "leaflet-measure": "^3.1.0",
     "leaflet-rotatedmarker": "^0.2.0",
     "leaflet-fullscreen": "^1.0.2",
+    "leaflet-transform": "^1.0.3",
     "underscore": "^1.8.3"
   },
   "jupyterlab": {

--- a/js/src/layers/Layer.js
+++ b/js/src/layers/Layer.js
@@ -67,6 +67,17 @@ var LeafletLayerView = utils.LeafletWidgetView.extend({
                 // This is a workaround for making maps rendered correctly in popups
                 window.dispatchEvent(new Event('resize'));
             });
+            // this layer is transformable
+            if (this.obj.transform) {
+                // add the handler only when the layer has been added
+                this.obj.on('add', () => {
+                    this.update_transform();
+                });
+                this.obj.on('transformed', () => {
+                    this.model.set('locations', this.obj.getLatLngs());
+                    this.touch();
+                });
+            }
         }
     },
 

--- a/js/src/layers/Path.js
+++ b/js/src/layers/Path.js
@@ -37,10 +37,7 @@ var LeafletPathView = LeafletVectorLayerView.extend({
             }, this);
         }
 
-        for (var i=0; i<o.length; i++) {
-            key = o[i];
-            this.obj.setStyle(this.get_options());
-        }
+        this.obj.setStyle(this.get_options());
     },
 
 });

--- a/js/src/layers/Polyline.js
+++ b/js/src/layers/Polyline.js
@@ -27,7 +27,30 @@ var LeafletPolylineView = LeafletPathView.extend({
         LeafletPolylineView.__super__.model_events.apply(this, arguments);
         this.listenTo(this.model, 'change:locations', function () {
             this.obj.setLatLngs(this.model.get('locations'));
+            if (this.obj.transform) {
+                this.obj.transform.reset();
+            }
         }, this);
+        this.model.on_some_change(['scaling', 'uniform_scaling', 'rotation'], this.update_transform, this);
+        this.listenTo(this.model, 'change:draggable', () => {
+            if (this.obj.dragging) {
+                this.obj.dragging[this.model.get('draggable') ? 'enable' : 'disable']();
+            }
+        }, this);
+        this.listenTo(this.model, 'change:transform', () => {
+            if (this.obj.transform) {
+                this.obj.transform[this.model.get('transform') ? 'enable' : 'disable']();
+            }
+        }, this);
+    },
+    update_transform: function () {
+        if (this.obj.transform) {
+            this.obj.transform.setOptions({
+                scaling:        this.model.get('scaling'),
+                uniformScaling: this.model.get('uniform_scaling'),
+                rotation:       this.model.get('rotation')
+                }).enable();
+        }
     },
 });
 

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -7,6 +7,7 @@ require('leaflet-measure');
 require('./leaflet-heat.js');
 require('leaflet-rotatedmarker');
 require('leaflet-fullscreen');
+require('leaflet-transform');
 
 // https://github.com/Leaflet/Leaflet/issues/4968
 // Marker file names are hard-coded in the leaflet source causing


### PR DESCRIPTION
This PR gives the possibility to transform (i.e. rotate and scale) and drag e.g. polygons. It vendors [Leaflet.Path.Transform](https://github.com/w8r/Leaflet.Path.Transform) and [Leaflet.Path.Drag](https://github.com/w8r/Leaflet.Path.Drag) because of bugs that could not be fixed upstream.
The `examples/Transform.ipynb` notebook illustrates the API.