### PR TITLE
Allow rendering GeoJSON points with CircleMarkers.

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -490,6 +490,7 @@ class GeoJSON(FeatureGroup):
     data = Dict().tag(sync=True)
     style = Dict().tag(sync=True)
     hover_style = Dict().tag(sync=True)
+    point_style = Dict().tag(sync=True)
 
     _click_callbacks = Instance(CallbackDispatcher, ())
     _hover_callbacks = Instance(CallbackDispatcher, ())

--- a/js/src/layers/GeoJSON.js
+++ b/js/src/layers/GeoJSON.js
@@ -10,17 +10,19 @@ var LeafletGeoJSONModel = featuregroup.LeafletFeatureGroupModel.extend({
         data : {},
         style : {},
         hover_style : {},
+        point_style : {},
     })
 });
 
 var LeafletGeoJSONView = featuregroup.LeafletFeatureGroupView.extend({
     create_obj: function () {
         var that = this;
-        style = function (feature) {
+        var style = function (feature) {
             var model_style = that.model.get('style');
             return _.extend(feature.properties.style || {}, model_style);
         }
-        this.obj = L.geoJson(this.model.get('data'), {
+
+        var options = {
             style: style,
             onEachFeature: function (feature, layer) {
                 var mouseevent = function (e) {
@@ -42,7 +44,17 @@ var LeafletGeoJSONView = featuregroup.LeafletFeatureGroupView.extend({
                     click: mouseevent
                 });
             }
-        });
+        };
+
+        var point_style = that.model.get('point_style');
+
+        if (Object.keys(point_style).length !== 0) {
+            options.pointToLayer = function(feature, latlng) {
+                return new L.CircleMarker(latlng, point_style)
+            }
+        }
+
+        this.obj = L.geoJson(this.model.get('data'), options);
     },
 
     model_events: function () {


### PR DESCRIPTION
Before this commit GeoJSON points where always rendered as 'map pins'.
Now users can pass all CircleMarker options to `GeoJSON` using the
`point_style` argument. If the argument is present and non-empty,
points will be rendered using CircleMarkers. If the argument is
ommitted or empty, points are rendered as 'map pins'.

This could serve as a solution for #188 and #362.