### PR TITLE
Add support for setting layer.popup to a Popup instance

### DIFF
--- a/js/src/layers/Layer.js
+++ b/js/src/layers/Layer.js
@@ -106,10 +106,15 @@ var LeafletLayerView = utils.LeafletWidgetView.extend({
         if (value) {
             var that = this;
             this.popup_content_promise = this.popup_content_promise.then(function() {
-                return that.create_child_view(value).then(function(view) {
-                    PMessaging.MessageLoop.sendMessage(view.pWidget, PWidgets.Widget.Msg.BeforeAttach);
-                    that.obj.bindPopup(view.el, that.popup_options());
-                    PMessaging.MessageLoop.sendMessage(view.pWidget, PWidgets.Widget.Msg.AfterAttach);
+                return that.create_child_view(value, {map_view: that.map_view}).then(function(view) {
+                    // If it's a Popup widget
+                    if (value.name == 'LeafletPopupModel') {
+                        that.obj.bindPopup(view.obj, that.popup_options());
+                    } else {
+                        PMessaging.MessageLoop.sendMessage(view.pWidget, PWidgets.Widget.Msg.BeforeAttach);
+                        that.obj.bindPopup(view.el, that.popup_options());
+                        PMessaging.MessageLoop.sendMessage(view.pWidget, PWidgets.Widget.Msg.AfterAttach);
+                    }
 
                     that.popup_content = view;
                     that.trigger('popup_content:created');


### PR DESCRIPTION
Should fix #447 

@PBrockmann the following code should do what you want with this branch.
```python
from ipywidgets import HTML

from ipyleaflet import Map, Marker, Popup, CircleMarker

center = (52.204793, 360.121558)

m = Map(center=center, zoom=9, close_popup_on_click=False)

#=============================================
marker1 = Marker(location=(52.1, 359.9))
m.add_layer(marker1)

message1 = HTML()
message1.value = "Hello 1"

marker1.popup = Popup(child=message1, auto_close=False)

#=============================================
marker2 = Marker(location=(52.1, 360.9))
m.add_layer(marker2)

message2 = HTML()
message2.value = "Hello 2"

marker2.popup = Popup(child=message2, auto_close=False)

m
```