### PR TITLE
Add support for font-awesome icons in Markers

### DIFF
--- a/examples/AwesomeIcons.ipynb
+++ b/examples/AwesomeIcons.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from ipyleaflet import AwesomeIcon, Marker, Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('./bars.json', 'r') as fobj:\n",
+    "    bars = json.load(fobj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for feature in bars['features']:\n",
+    "    symbol = feature['properties']['marker-symbol']\n",
+    "    coords = feature['geometry']['coordinates']\n",
+    "    \n",
+    "    icon = AwesomeIcon(\n",
+    "        name=symbol,\n",
+    "        marker_color='red' if symbol == 'bus' else 'blue'\n",
+    "    )\n",
+    "    markers.append(Marker(icon=icon, location=(coords[1], coords[0])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=(38.91342738235981, -77.03912909142674), zoom=13)\n",
+    "\n",
+    "for marker in markers:\n",
+    "    m += marker\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers[0].icon = AwesomeIcon(name='spinner', marker_color='green', icon_color='darkgreen', spin=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/bars.json
+++ b/examples/bars.json
@@ -1,0 +1,142 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.039882,
+          38.898321
+        ]
+      },
+      "properties": {
+        "marker-symbol": "bus",
+        "name": "The Exchange",
+        "address": "1719 G St NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.038193,
+          38.901345
+        ]
+      },
+      "properties": {
+        "marker-symbol": "bus",
+        "name": "Blackfin",
+        "address": "1620 I St NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.03195,
+          38.907826
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "Churchkey",
+        "address": "1337 14th St NW",
+        "note": "Ask the bartender for the password"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.0276460,
+          38.9007690
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "Capitol City Brewing Company",
+        "address": "1100 New York Ave NW",
+        "note": "Ask the bartender for the password"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.036554,
+          38.900201
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "Off The Record",
+        "address": "800 16th St NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.071309,
+          38.919986
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "breadsoda",
+        "address": "2233 Wisconsin Ave NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.042084,
+          38.906459
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "St. Arnold's on Jefferson",
+        "address": "1827 Jefferson Pl NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.028620,
+          38.931821
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "Meridian Pint",
+        "address": "3400 11th St NW"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.070275,
+          38.906094
+        ]
+      },
+      "properties": {
+        "marker-symbol": "glass",
+        "name": "The Tombs",
+        "address": "1226 36th St NW"
+      }
+    }
+  ]
+}

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -163,6 +163,19 @@ class Icon(UILayer):
     popup_anchor = Tuple((0, 0), allow_none=True).tag(sync=True, o=True)
 
 
+class AwesomeIcon(UILayer):
+    _view_name = Unicode('LeafletAwesomeIconView').tag(sync=True)
+    _model_name = Unicode('LeafletAwesomeIconModel').tag(sync=True)
+
+    name = Unicode('home').tag(sync=True)
+    marker_color = Enum(
+        values=['white', 'red', 'darkred', 'lightred', 'orange', 'beige', 'green', 'darkgreen', 'lightgreen', 'blue', 'darkblue', 'lightblue', 'purple', 'darkpurple', 'pink', 'cadetblue', 'white', 'gray', 'lightgray', 'black'],
+        default_value='blue'
+    ).tag(sync=True)
+    icon_color = Color('white').tag(sync=True)
+    spin = Bool(False).tag(sync=True)
+
+
 class Marker(UILayer):
     _view_name = Unicode('LeafletMarkerView').tag(sync=True)
     _model_name = Unicode('LeafletMarkerModel').tag(sync=True)
@@ -170,7 +183,7 @@ class Marker(UILayer):
     location = List(def_loc).tag(sync=True)
     opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True)
     visible = Bool(True).tag(sync=True)
-    icon = Instance(Icon, allow_none=True, default_value=None).tag(sync=True, **widget_serialization)
+    icon = Union((Instance(Icon), Instance(AwesomeIcon)), allow_none=True, default_value=None).tag(sync=True, **widget_serialization)
 
     # Options
     z_index_offset = Int(0).tag(sync=True, o=True)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1426,8 +1426,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -1494,7 +1493,6 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -1503,7 +1501,6 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -1521,8 +1518,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1539,8 +1535,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -1560,20 +1555,17 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -1646,8 +1638,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1669,14 +1660,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -1732,7 +1721,6 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1745,8 +1733,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -1774,7 +1761,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -1785,8 +1771,7 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -1803,7 +1788,6 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -1812,8 +1796,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
@@ -1825,7 +1808,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -1839,8 +1821,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -1929,7 +1910,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
@@ -1944,7 +1924,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2018,7 +1997,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2048,8 +2026,7 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -2060,8 +2037,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2099,7 +2075,6 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2144,7 +2119,6 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -2152,8 +2126,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2177,7 +2150,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2211,7 +2183,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2222,7 +2193,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2237,7 +2207,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2252,7 +2221,6 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -2308,8 +2276,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2338,8 +2305,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2891,6 +2857,11 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/leaflet-velocity/-/leaflet-velocity-1.2.4.tgz",
       "integrity": "sha1-xDHkAntjKu43RUvQNCmvpDbjso0="
+    },
+    "leaflet.awesome-markers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/leaflet.awesome-markers/-/leaflet.awesome-markers-2.0.5.tgz",
+      "integrity": "sha512-Ne/xDjkGyaujwNVVkv2tyXQUV0ZW7gZ0Mo0FuQY4jp2qWrvXi0hwDBvmZyF/8YOvybyMabTMM/mFWCTd1jZIQA=="
     },
     "leaflet.markercluster": {
       "version": "1.3.0",

--- a/js/package.json
+++ b/js/package.json
@@ -32,17 +32,18 @@
   "dependencies": {
     "@jupyter-widgets/base": "^2.0",
     "leaflet": "^1.3.0",
+    "leaflet-ant-path": "^1.3.0",
     "leaflet-draw": "^1.0.4",
-    "leaflet.markercluster": "^1.2.0",
-    "leaflet-splitmap": "^1.0.1",
-    "leaflet-velocity": "^1.2.4",
+    "leaflet-fullscreen": "^1.0.2",
     "leaflet-measure": "^3.1.0",
     "leaflet-rotatedmarker": "^0.2.0",
-    "leaflet-fullscreen": "^1.0.2",
+    "leaflet-splitmap": "^1.0.1",
     "leaflet-transform": "^1.0.3",
-    "leaflet-ant-path": "^1.3.0",
-    "underscore": "^1.8.3",
-    "spin.js": "^4.1.0"
+    "leaflet-velocity": "^1.2.4",
+    "leaflet.awesome-markers": "^2.0.5",
+    "leaflet.markercluster": "^1.2.0",
+    "spin.js": "^4.1.0",
+    "underscore": "^1.8.3"
   },
   "jupyterlab": {
     "extension": "src/jupyterlab-plugin"

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -5,6 +5,7 @@
 var layer = require('./layers/Layer.js');
 var marker = require('./layers/Marker.js');
 var icon = require('./layers/Icon.js');
+var awesomeicon = require('./layers/AwesomeIcon.js');
 var popup = require('./layers/Popup.js');
 var rasterlayer = require('./layers/RasterLayer.js');
 var tilelayer = require('./layers/TileLayer.js');
@@ -48,6 +49,7 @@ require('leaflet.markercluster/dist/MarkerCluster.css');
 require('leaflet.markercluster/dist/MarkerCluster.Default.css');
 require('leaflet-measure/dist/leaflet-measure.css');
 require('leaflet-fullscreen/dist/leaflet.fullscreen.css');
+require('leaflet.awesome-markers/dist/leaflet.awesome-markers.css');
 require('spin.js/spin.css');
 require('./jupyter-leaflet.css');
 
@@ -62,6 +64,7 @@ module.exports = {
     LeafletLayerView : layer.LeafletLayerView,
     LeafletUILayerView : layer.LeafletUILayerView,
     LeafletIconView : icon.LeafletIconView,
+    LeafletAwesomeIconView : awesomeicon.LeafletAwesomeIconView,
     LeafletMarkerView : marker.LeafletMarkerView,
     LeafletPopupView : popup.LeafletPopupView,
     LeafletRasterLayerView : rasterlayer.LeafletRasterLayerView,
@@ -99,6 +102,7 @@ module.exports = {
     LeafletLayerModel : layer.LeafletLayerModel,
     LeafletUILayerModel : layer.LeafletUILayerModel,
     LeafletIconModel : icon.LeafletIconModel,
+    LeafletAwesomeIconModel : awesomeicon.LeafletAwesomeIconModel,
     LeafletMarkerModel :marker.LeafletMarkerModel,
     LeafletPopupModel : popup.LeafletPopupModel,
     LeafletRasterLayerModel : rasterlayer.LeafletRasterLayerModel,

--- a/js/src/layers/AwesomeIcon.js
+++ b/js/src/layers/AwesomeIcon.js
@@ -1,0 +1,37 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+var widgets = require('@jupyter-widgets/base');
+var _ = require('underscore');
+var L = require('../leaflet.js');
+var layer = require('./Layer.js');
+
+var LeafletAwesomeIconModel = layer.LeafletUILayerModel.extend({
+    defaults: _.extend({}, layer.LeafletUILayerModel.prototype.defaults, {
+        _view_name :'LeafletAwesomeIconView',
+        _model_name : 'LeafletAwesomeIconModel',
+        name: 'home',
+        marker_color: 'blue',
+        icon_color: 'blue',
+        spin: false
+    })
+});
+
+var LeafletAwesomeIconView = layer.LeafletUILayerView.extend({
+
+    create_obj: function () {
+        this.obj = L.AwesomeMarkers.icon({
+            prefix: 'fa',
+            icon: this.model.get('name'),
+            markerColor: this.model.get('marker_color'),
+            iconColor: this.model.get('icon_color'),
+            spin: this.model.get('spin')
+        });
+    }
+
+});
+
+module.exports = {
+  LeafletAwesomeIconView : LeafletAwesomeIconView,
+  LeafletAwesomeIconModel : LeafletAwesomeIconModel,
+};

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -8,6 +8,7 @@ require('./leaflet-heat.js');
 require('leaflet-rotatedmarker');
 require('leaflet-fullscreen');
 require('leaflet-transform');
+require('leaflet.awesome-markers');
 
 // https://github.com/Leaflet/Leaflet/issues/4968
 // Marker file names are hard-coded in the leaflet source causing


### PR DESCRIPTION
![icons2](https://user-images.githubusercontent.com/21197331/72082497-899ce980-3300-11ea-9498-775ba5ea9f6e.png)

Related to https://github.com/jupyter-widgets/ipyleaflet/issues/83, it does not add automatic support in the GeoJSON layer though.