### PR TITLE
Sync Path's fill_color with color

### DIFF
--- a/docs/source/api_reference/circle.rst
+++ b/docs/source/api_reference/circle.rst
@@ -36,7 +36,7 @@ color             "#0033FF"          Stroke color
 opacity           1.0                Stroke opacity
 weight            5                  Stroke width in pixels
 fill              True               Whether to fill the circle or not
-fill_color        "#0033FF"
+fill_color        None
 fill_opacity      0.2
 dash_array
 line_cap          "round"

--- a/docs/source/api_reference/circle_marker.rst
+++ b/docs/source/api_reference/circle_marker.rst
@@ -36,7 +36,7 @@ color             "#0033FF"          Stroke color
 opacity           1.0                Stroke opacity
 weight            5                  Stroke width in pixels
 fill              True               Whether to fill the circle or not
-fill_color        "#0033FF"
+fill_color        None
 fill_opacity      0.2
 dash_array
 line_cap          "round"

--- a/docs/source/api_reference/polygon.rst
+++ b/docs/source/api_reference/polygon.rst
@@ -72,7 +72,7 @@ color            "#0033FF"          Stroke color
 opacity          1.0                Stroke opacity
 weight           5                  Stroke width in pixels
 fill             True               Whether to fill the polygon or not
-fill_color       "#0033FF"
+fill_color       None
 fill_opacity     0.2
 dash_array
 line_cap         "round"

--- a/docs/source/api_reference/polyline.rst
+++ b/docs/source/api_reference/polyline.rst
@@ -61,7 +61,7 @@ color            "#0033FF"          Stroke color
 opacity          1.0                Stroke opacity
 weight           5                  Stroke width in pixels
 fill             True               Whether to fill the polyline or not
-fill_color       "#0033FF"
+fill_color       None
 fill_opacity     0.2
 dash_array
 line_cap         "round"

--- a/docs/source/api_reference/rectangle.rst
+++ b/docs/source/api_reference/rectangle.rst
@@ -31,7 +31,7 @@ color               "#0033FF"          Stroke color
 opacity             1.0                Stroke opacity
 weight              5                  Stroke width in pixels
 fill                True               Whether to fill the polygon or not
-fill_color          "#0033FF"
+fill_color          None
 fill_opacity        0.2
 dash_array
 line_cap            "round"

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -399,7 +399,7 @@ class Path(VectorLayer):
     color = Color('#0033FF').tag(sync=True, o=True)
     weight = Int(5).tag(sync=True, o=True)
     fill = Bool(True).tag(sync=True, o=True)
-    fill_color = Color('#0033FF').tag(sync=True, o=True)
+    fill_color = Color(None, allow_none=True).tag(sync=True, o=True)
     fill_opacity = Float(0.2).tag(sync=True, o=True)
     dash_array = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
     line_cap = Unicode('round').tag(sync=True, o=True)

--- a/js/src/layers/Path.js
+++ b/js/src/layers/Path.js
@@ -13,7 +13,7 @@ export class LeafletPathModel extends vectorlayer.LeafletVectorLayerModel {
       color: '#0033FF',
       weight: 5,
       fill: true,
-      fill_color: '#0033FF',
+      fill_color: null,
       fill_opacity: 0.2,
       dash_array: null,
       line_cap: 'round',


### PR DESCRIPTION
This PR fills circle marker and other objects with the same color as the stroke color except for the opacity.

```python
from ipyleaflet import CircleMarker, Map

m = Map()
m.add_layer(CircleMarker(color='#d9a89c', fill_opacity=0.5, radius=100))
m
```

|  w/o PR  |  w/ PR |
| ---- | ---- |
| ![before](https://user-images.githubusercontent.com/13291527/75056864-2ca96b80-551b-11ea-826d-e66b6e82eeda.png) | ![after](https://user-images.githubusercontent.com/13291527/75056885-3a5ef100-551b-11ea-894a-5d4b609c030d.png) |

In Leaflet, the value of `Path`'s `fillColor` option defaults to its `color` value as is documented [here](https://leafletjs.com/reference-1.6.0.html#path-fillcolor). So I modified ipyleaflet accordingly.

IMHO this would be the behavior users find comfortable (at least I do), but feel free to close if ipyleaflet has some background not to be aligned with Leaflet.