### PR TITLE
Fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 recursive-include ipyleaflet/static *.*
 include jupyter-leaflet.json
+include js/*tgz
+include js/package.json

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def js_prerelease(command, strict=False):
 
 
 def get_data_files():
-    with open(os.path.join('js', 'package.json')) as f:
+    with open(os.path.join(node_root, 'package.json')) as f:
         package_json = json.load(f)
     tgz = '%s-%s.tgz' % (package_json['name'], package_json['version'])
 


### PR DESCRIPTION
The package.json file and the .tgz should be included in the distribution.

The package.json is needed by the setup.py for the js version, which was not the case before. And the .tgz file is needed for the JupyterLab extension installation.