### PR TITLE
Renamed positional argument for handle_draw()

### DIFF
--- a/examples/DrawControl.ipynb
+++ b/examples/DrawControl.ipynb
@@ -66,7 +66,7 @@
     "                 circlemarker={},\n",
     "                 )\n",
     "\n",
-    "def handle_draw(self, action, geo_json):\n",
+    "def handle_draw(target, action, geo_json):\n",
     "    print(action)\n",
     "    print(geo_json)\n",
     "\n",
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Renamed the positional argument from `self` to `target` to avoid confusion. 