### PR TITLE
Fixed basemap name typo

### DIFF
--- a/examples/DropdownControl.ipynb
+++ b/examples/DropdownControl.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import basemaps,basemap_to_tiles, Map, WidgetControl\n",
+    "from ipywidgets import Dropdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=[0, 0], zoom=2)\n",
+    "\n",
+    "ee_basemaps={}\n",
+    "\n",
+    "# Loops through all ipyleaflet basemaps\n",
+    "for item in basemaps.values():\n",
+    "    try:\n",
+    "        name = item['name']\n",
+    "        basemap = 'basemaps.{}'.format(name)\n",
+    "        ee_basemaps[name] = basemap_to_tiles(eval(basemap))\n",
+    "    except:\n",
+    "        for sub_item in item:\n",
+    "            name = item[sub_item]['name']\n",
+    "            basemap = 'basemaps.{}'.format(name)\n",
+    "            basemap = basemap.replace('Mids', 'Modis')\n",
+    "            ee_basemaps[name] = basemap_to_tiles(eval(basemap))\n",
+    "\n",
+    "# Adds a Dropdown widget\n",
+    "dropdown = Dropdown(\n",
+    "    options=list(ee_basemaps.keys()),\n",
+    "    value='OpenStreetMap.Mapnik',\n",
+    "    description='Basemaps'\n",
+    ")\n",
+    "\n",
+    "# Handles Dropdown control event\n",
+    "def on_click(change):\n",
+    "    basemap_name = change['new']\n",
+    "    old_basemap = m.layers[-1]\n",
+    "    m.substitute_layer(old_basemap, ee_basemaps[basemap_name])\n",
+    "    \n",
+    "dropdown.observe(on_click, 'value')\n",
+    "\n",
+    "# Adds control to the map\n",
+    "basemap_control = WidgetControl(widget=dropdown, position='topright')\n",
+    "m.add_control(basemap_control)\n",
+    "\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ipyleaflet/basemaps.py
+++ b/ipyleaflet/basemaps.py
@@ -135,7 +135,7 @@ basemaps = Bunch(
             url='https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',
             max_zoom=9,
             attribution='Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
-            name='NASAGIBS.MidsTerraBands721CR'
+            name='NASAGIBS.ModisTerraBands721CR'
         ),
         ModisAquaTrueColorCR=dict(
             url='https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/%s/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg',


### PR DESCRIPTION
I discovered this typo when trying to loop through the basemaps using the name attribute. `MidsTerraBands721CR` should be corrected to `ModisTerraBands721CR`.

```
from ipyleaflet import basemaps
for item in basemaps.values():
    try:
        basemap = 'basemaps.{}'.format(item['name'])
        print(eval(basemap))
    except:
        for sub_item in item:
            basemap = 'basemaps.{}'.format(item[sub_item]['name'])
#             basemap = basemap.replace('Mids', 'Modis')
            print(eval(basemap))

```