### PR TITLE
Fixed typos in docs

### DIFF
--- a/docs/source/api_reference/map.rst
+++ b/docs/source/api_reference/map.rst
@@ -59,6 +59,7 @@ Method             Arguments                                 Doc
 ================   =====================================     ===
 add_layer          Layer instance                            Add a new layer to the map
 remove_layer       Layer instance                            Remove a layer from the map
+substitute_layer   Layer instance                            Substitute a layer with a new layer
 clear_layers                                                 Remove all layers from the map
 add_control        Control instance                          Add a new control to the map
 remove_control     Control instance                          Remove a control from the map

--- a/docs/source/api_reference/widget_control.rst
+++ b/docs/source/api_reference/widget_control.rst
@@ -30,7 +30,7 @@ Attribute           Default Value      Doc
 position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
 widget              None               Widget content
 min_width           None               Min width of the widget (in pixels), if None it will respect the content size
-max_width           None               Min width of the widget (in pixels), if None it will respect the content size
+max_width           None               Max width of the widget (in pixels), if None it will respect the content size
 min_height          None               Min height of the widget (in pixels), if None it will respect the content size
-max_height          None               Min height of the widget (in pixels), if None it will respect the content size
+max_height          None               Max height of the widget (in pixels), if None it will respect the content size
 ================    ================   ===


### PR DESCRIPTION
Corrected two typos and added `substitute_layer` to the Map methods.