### PR TITLE
Make Github ignore js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-detectable=false


### PR DESCRIPTION
This should fix the "used by" button