### PR TITLE
Remove xarray dependency 

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -334,8 +334,9 @@ class Velocity(Layer):
     except ModuleNotFoundError:
         raise ImportError(
             'The `xarray` module (required for use of the Velocity layer) is'
-            'not installed. Run "$ pip install xarray" to install the latest'
-            'version.'
+            'not installed. Run "$ conda install -c conda-forge xarray dask'
+            'netCDF4 bottleneck" or "$ pip install xarray" to install the '
+            'latest version.'
         )
 
     _view_name = Unicode('LeafletVelocityView').tag(sync=True)

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -329,6 +329,15 @@ class VideoOverlay(RasterLayer):
 
 
 class Velocity(Layer):
+    try:
+        import xarray
+    except ModuleNotFoundError:
+        raise ImportError(
+            'The `xarray` module (required for use of the Velocity layer) is'
+            'not installed. Run "$ pip install xarray" to install the latest'
+            'version.'
+        )
+
     _view_name = Unicode('LeafletVelocityView').tag(sync=True)
     _model_name = Unicode('LeafletVelocityModel').tag(sync=True)
 

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -334,9 +334,7 @@ class Velocity(Layer):
     except ModuleNotFoundError:
         raise ImportError(
             'The `xarray` module (required for use of the Velocity layer) is'
-            'not installed. Run "$ conda install -c conda-forge xarray dask'
-            'netCDF4 bottleneck" or "$ pip install xarray" to install the '
-            'latest version.'
+            'not installed.'
         )
 
     _view_name = Unicode('LeafletVelocityView').tag(sync=True)

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -333,7 +333,7 @@ class Velocity(Layer):
         import xarray
     except ModuleNotFoundError:
         raise ImportError(
-            'The `xarray` module (required for use of the Velocity layer) is'
+            'The `xarray` module (required for use of the Velocity layer) is '
             'not installed.'
         )
 

--- a/setup.py
+++ b/setup.py
@@ -137,8 +137,7 @@ setup_args = {
     'install_requires': [
         'ipywidgets>=7.5.0,<8',
         'traittypes>=0.2.1,<3',
-        'xarray>=0.10',
-        'branca>=0.3.1,<0.4'
+        'branca>=0.3.1,<0.4',
     ],
     'packages': find_packages(),
     'zip_safe': False,


### PR DESCRIPTION
Removes `xarray` from the dependencies of ipyleaflet.

Although ipyleaflet has `xarray` listed in its `install_requires` I'm not exactly sure why it needs this dependency. It would be great if when I installed ipyleaflet, I didn't also have to install `xarray` (which, in turn, pulls in `pandas`) as a transitive dependency. 