### PR TITLE
Add missing dependencies: @phosphor/messaging @phosphor/widgets

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2 || ^3",
+    "@phosphor/messaging": "^1.3.0",
+    "@phosphor/widgets": "^1.9.3",
     "leaflet": "^1.3.0",
     "leaflet-ant-path": "^1.3.0",
     "leaflet-defaulticon-compatibility": "^0.1.1",


### PR DESCRIPTION
fixing this issue : https://github.com/jupyter-widgets/ipyleaflet/issues/562