### PR TITLE
Fix VectorTile layer

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -397,10 +397,6 @@ class VectorTileLayer(Layer):
 
     vector_tile_layer_styles = Dict().tag(sync=True, o=True)
 
-    def __init__(self, **kwargs):
-        super(VectorTileLayer, self).__init__(**kwargs)
-        self.on_msg(self._handle_leaflet_event)
-
     def redraw(self):
         self.send({'msg': 'redraw'})
 


### PR DESCRIPTION
The VectorTile layer is actually not working in the latest release (my fault :confused:), the constructor was calling a non-existing method

@omanges 