### PR TITLE
bug fix for the PR #559 which was raised for issue #555

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -571,16 +571,28 @@ class GeoJSON(FeatureGroup):
     def _get_data(self):
         if self.style_callback:
             if self.data['type'] == 'Feature':
-                self.data['properties']['style'].update(self.style_callback(self.data))
+                if 'style' in self.data['properties']:
+                    self.data['properties']['style'].update(self.style_callback(self.data))
+                else:
+                    self.data['properties']['style'] = self.style_callback(self.data)
             elif self.data['type'] == 'FeatureCollection':
                 for feature in self.data['features']:
-                    feature['properties']['style'].update(self.style_callback(feature))
+                    if 'style' in feature['properties']:
+                        feature['properties']['style'].update(self.style_callback(feature))
+                    else:
+                        feature['properties']['style'] = self.style_callback(feature)
         elif self.style:
             if self.data['type'] == 'Feature':
-                self.data['properties']['style'].update(self.style)
+                if 'style' in self.data['properties']:
+                    self.data['properties']['style'].update(self.style)
+                else:
+                    self.data['properties']['style'] = self.style
             elif self.data['type'] == 'FeatureCollection':
                 for feature in self.data['features']:
-                    feature['properties']['style'].update(self.style)
+                    if 'style' in feature['properties']:
+                        feature['properties']['style'].update(self.style)
+                    else:
+                        feature['properties']['style'] = self.style
         return self.data
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
There was small bug in PR #559  if `style `is not present in input geojson properties, it fails with KeyError while updating style, Hence I added check for it. If style is present in input geojson properties then update the style provided by the user else assign the style.

e.g. from CountriesGeojson notebook
```python
import ipyleaflet as ipyl
import ipywidgets as ipyw
import json
map = ipyl.Map(center=[53.88, 27.45], zoom=4)
label = ipyw.Label(layout=ipyw.Layout(width='100%'))

# geojson layer with hover handler
with open('./europe_110.geo.json') as f:
    data = json.load(f)
layer = ipyl.GeoJSON(data=data, hover_style={'fillColor': 'red'}, style = {'color': 'green', 'opacity':1, 'weight':1.9, 'dashArray':'9', 'fillOpacity':0.1})
```
This was failing with `KeyError` `style`
I have handled this in my changes.

@martinRenou - will you please review this.