### PR TITLE
Add window_url attribute to Map

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -943,6 +943,9 @@ class Map(DOMWidget, InteractMixin):
     _view_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
     _model_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
 
+    # URL of the window where the map is displayed
+    window_url = Unicode(read_only=True).tag(sync=True)
+
     # Map options
     center = List(def_loc).tag(sync=True, o=True)
     zoom_start = CFloat(12).tag(sync=True, o=True)

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -34,7 +34,6 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
       _model_module: 'jupyter-leaflet',
       _view_module: 'jupyter-leaflet',
 
-      window_url: '',
       center: DEFAULT_LOCATION,
       zoom_start: 12,
       zoom: 12,
@@ -76,6 +75,11 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
     };
   }
 
+  initialize(attributes, options) {
+    super.initialize(attributes, options);
+    this.set('window_url', window.location.href);
+  }
+
   update_style() {
     if (!this.get('_dragging')) {
       var new_style = this.get('default_style');
@@ -108,7 +112,6 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
       this.set('south', bounds.south);
       this.set('east', bounds.east);
       this.set('west', bounds.west);
-      this.set('window_url', window.location.href);
     });
   }
 }

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -34,6 +34,7 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
       _model_module: 'jupyter-leaflet',
       _view_module: 'jupyter-leaflet',
 
+      window_url: '',
       center: DEFAULT_LOCATION,
       zoom_start: 12,
       zoom: 12,
@@ -107,6 +108,7 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
       this.set('south', bounds.south);
       this.set('east', bounds.east);
       this.set('west', bounds.west);
+      this.set('window_url', window.location.href);
     });
   }
 }


### PR DESCRIPTION
It can be useful to retrieve the URL of the browser window when we want to serve local tiles with `LocalTileLayer` through a custom Jupyter server handler.