### PR TITLE
Add pixel_bounds to Map

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1032,6 +1032,11 @@ class Map(DOMWidget, InteractMixin):
     east = Float(def_loc[1], read_only=True).tag(sync=True)
     west = Float(def_loc[1], read_only=True).tag(sync=True)
 
+    bottom = Int(0, read_only=True).tag(sync=True)
+    top = Int(9007199254740991, read_only=True).tag(sync=True)
+    right = Int(0, read_only=True).tag(sync=True)
+    left = Int(9007199254740991, read_only=True).tag(sync=True)
+
     layers = Tuple().tag(trait=Instance(Layer), sync=True, **widget_serialization)
 
     @default('layers')
@@ -1045,6 +1050,7 @@ class Map(DOMWidget, InteractMixin):
 
     bounds = Tuple(read_only=True)
     bounds_polygon = Tuple(read_only=True)
+    pixel_bounds = Tuple(read_only=True)
 
     @observe('south', 'north', 'east', 'west')
     def _observe_bounds(self, change):
@@ -1054,6 +1060,11 @@ class Map(DOMWidget, InteractMixin):
                                           (self.north, self.east),
                                           (self.south, self.east),
                                           (self.south, self.west)))
+
+    @observe('bottom', 'top', 'right', 'left')
+    def _observe_pixel_bounds(self, change):
+        self.set_trait('pixel_bounds', ((self.left, self.top),
+                                        (self.right, self.bottom)))
 
     def __init__(self, **kwargs):
         self.zoom_control_instance = None

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -68,6 +68,10 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
       north: DEFAULT_LOCATION[0],
       east: DEFAULT_LOCATION[1],
       west: DEFAULT_LOCATION[1],
+      bottom: 0,
+      top: 9007199254740991,
+      right: 0,
+      left: 9007199254740991,
       options: [],
       layers: [],
       controls: [],
@@ -106,7 +110,15 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
         east: -180,
         west: 180
       };
-      Object.keys(views).reduce(function (bnds, key) {
+      var pixel_bounds = {
+        top: 9007199254740991,
+        bottom: 0,
+        right: 0,
+        left: 9007199254740991
+      };
+      Object.keys(views).reduce(function (bnds_pixbnds, key) {
+        var bnds = bnds_pixbnds[0];
+        var pixbnds = bnds_pixbnds[1];
         var obj = views[key].obj;
         if (obj) {
           var view_bounds = obj.getBounds();
@@ -114,13 +126,24 @@ export class LeafletMapModel extends widgets.DOMWidgetModel {
           bnds.south = Math.min(bnds.south, view_bounds.getSouth());
           bnds.east = Math.max(bnds.east, view_bounds.getEast());
           bnds.west = Math.min(bnds.west, view_bounds.getWest());
+          var view_pixel_bounds = obj.getPixelBounds();
+          var top_left = view_pixel_bounds.getTopLeft();
+          var bottom_right = view_pixel_bounds.getBottomRight();
+          pixbnds.top = Math.min(pixbnds.top, top_left.y);
+          pixbnds.bottom = Math.max(pixbnds.bottom, bottom_right.y);
+          pixbnds.right = Math.max(pixbnds.right, bottom_right.x);
+          pixbnds.left = Math.min(pixbnds.left, top_left.x);
         }
-        return bnds;
-      }, bounds);
+        return [bnds, pixbnds];
+      }, [bounds, pixel_bounds]);
       this.set('north', bounds.north);
       this.set('south', bounds.south);
       this.set('east', bounds.east);
       this.set('west', bounds.west);
+      this.set('top', pixel_bounds.top);
+      this.set('bottom', pixel_bounds.bottom);
+      this.set('right', pixel_bounds.right);
+      this.set('left', pixel_bounds.left);
     });
   }
 }


### PR DESCRIPTION
Similar to the `bounds` read-only attribute, but in projected pixel coordinates instead of lat/lon coordinates (see https://leafletjs.com/reference-1.0.3.html#map-getpixelbounds).
While `bounds` is `((south, west), (north, east))`, `pixel_bounds` is `((left, top), (right, bottom))` to respect the Leaflet convention.