### PR TITLE
Fix EPSG:3413 and EPSG:3031

### DIFF
--- a/ipyleaflet/projections.py
+++ b/ipyleaflet/projections.py
@@ -51,9 +51,10 @@ projections = Bunch(
         custom=True,
         proj4def="""+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0
                  +ellps=WGS84 +datum=WGS84 +units=m +no_defs""",
-        # origin and bounds for 500m resolution
-        origin=[-4194304 / 2, 4194304 / 2],
+        # origin and bounds for 250m resolution
+        origin=[-4194304, 4194304],
         resolutions=[
+            16384.0,
             8192.0,
             4096.0,
             2048.0,
@@ -62,8 +63,8 @@ projections = Bunch(
             256.0
         ],
         bounds=[
-            [-4194304 / 2, -4194304 / 2],
-            [4194304 / 2, 4194304 / 2]
+            [-4194304, -4194304],
+            [4194304, 4194304]
         ]
     )
 )

--- a/ipyleaflet/projections.py
+++ b/ipyleaflet/projections.py
@@ -30,7 +30,6 @@ projections = Bunch(
         custom=True,
         proj4def="""+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0
                  +ellps=WGS84 +datum=WGS84 +units=m +no_defs""",
-        # origin and bounds for 250m resolution
         origin=[-4194304, 4194304],
         resolutions=[
             16384.0,
@@ -51,7 +50,6 @@ projections = Bunch(
         custom=True,
         proj4def="""+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0
                  +ellps=WGS84 +datum=WGS84 +units=m +no_defs""",
-        # origin and bounds for 250m resolution
         origin=[-4194304, 4194304],
         resolutions=[
             16384.0,

--- a/ipyleaflet/projections.py
+++ b/ipyleaflet/projections.py
@@ -30,9 +30,10 @@ projections = Bunch(
         custom=True,
         proj4def="""+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0
                  +ellps=WGS84 +datum=WGS84 +units=m +no_defs""",
-        # origin and bounds for 500m resolution
-        origin=[-4194304 / 2, 4194304 / 2],
+        # origin and bounds for 250m resolution
+        origin=[-4194304, 4194304],
         resolutions=[
+            16384.0,
             8192.0,
             4096.0,
             2048.0,
@@ -41,8 +42,8 @@ projections = Bunch(
             256.0
         ],
         bounds=[
-            [-4194304 / 2, -4194304 / 2],
-            [4194304 / 2, 4194304 / 2]
+            [-4194304, -4194304],
+            [4194304, 4194304]
         ]
     ),
     EPSG3031=dict(


### PR DESCRIPTION
This is applying [this change](https://github.com/jupyter-widgets/ipyleaflet/issues/612#issuecomment-641761444).
@betolink I also changed the comment to `origin and bounds for 250m resolution` instead of 500m, is this correct?
Should we do the same for `EPSG:3031`?