### PR TITLE
Implement __geo_interface__ for relevant classes

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -545,6 +545,16 @@ class GeoJSON(FeatureGroup):
 
         return self.data
 
+    @property
+    def __geo_interface__(self):
+        """
+        Return a dict whose structure aligns to the GeoJSON format
+        For more information about the ``__geo_interface__``, see
+        https://gist.github.com/sgillies/2217756
+        """
+
+        return self.data
+
     def _apply_style(self, feature, style_callback):
         if 'properties' not in feature:
             feature['properties'] = {}
@@ -595,6 +605,9 @@ class GeoData(GeoJSON):
     def _get_data(self):
         return json.loads(self.geo_dataframe.to_json())
 
+    @property
+    def __geo_interface__(self):
+        return self.geo_dataframe.__geo_interface__
 
 class Choropleth(GeoJSON):
     geo_data = Dict()

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -607,7 +607,14 @@ class GeoData(GeoJSON):
 
     @property
     def __geo_interface__(self):
+        """
+        Return a dict whose structure aligns to the GeoJSON format
+        For more information about the ``__geo_interface__``, see
+        https://gist.github.com/sgillies/2217756
+        """
+
         return self.geo_dataframe.__geo_interface__
+
 
 class Choropleth(GeoJSON):
     geo_data = Dict()


### PR DESCRIPTION

This PR implements the [`__geo_interface__` spec][spec] for `GeoJSON`, `Choropleth`, and `GeoData`. For `GeoData` we fall back to `geopandas` implementation on the `GeoDataFrame`.

Note that as is the convention with GeoDataFrame a` {'type': 'FeatureCollection', ...}` can be returned. This is not explicitly stated in the spec but the comments lobby for it and ask the geopandas contributors to expand on their approach.

[spec]: https://gist.github.com/sgillies/2217756


This is my first contribution to the project so I appreciate your attention and  patience!
