### PR TITLE
Fix bounds type

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1253,10 +1253,10 @@ class Map(DOMWidget, InteractMixin):
     east = Float(def_loc[1], read_only=True).tag(sync=True)
     west = Float(def_loc[1], read_only=True).tag(sync=True)
 
-    bottom = Int(0, read_only=True).tag(sync=True)
-    top = Int(9007199254740991, read_only=True).tag(sync=True)
-    right = Int(0, read_only=True).tag(sync=True)
-    left = Int(9007199254740991, read_only=True).tag(sync=True)
+    bottom = Float(0, read_only=True).tag(sync=True)
+    top = Float(9007199254740991, read_only=True).tag(sync=True)
+    right = Float(0, read_only=True).tag(sync=True)
+    left = Float(9007199254740991, read_only=True).tag(sync=True)
 
     layers = Tuple().tag(trait=Instance(Layer), sync=True, **widget_serialization)
 


### PR DESCRIPTION
This was resulting in some issues when panning:

![ipyleaflet](https://user-images.githubusercontent.com/21197331/85030545-da512200-b17d-11ea-8c06-20e56e9e308c.png)
