### PR TITLE
Pin branca>=0.3.1,<0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup_args = {
     'install_requires': [
         'ipywidgets>=7.5.0,<8',
         'traittypes>=0.2.1,<3',
-        'branca>=0.3.1,<0.4',
+        'branca>=0.3.1,<0.5',
     ],
     'packages': find_packages(),
     'zip_safe': False,


### PR DESCRIPTION
I checked that `examples/Choropleth.ipynb` works fine with `branca==0.4.1`.
Fixes #638 