### PR TITLE
Add dependency of shapely separately as Geopandas is dependency for building docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup_args = dict(
         'ipywidgets>=7.5.0,<8',
         'traittypes>=0.2.1,<3',
         'branca>=0.3.1,<0.5',
+        'Shapely>=1.7.1',
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup_args = dict(
         'ipywidgets>=7.5.0,<8',
         'traittypes>=0.2.1,<3',
         'branca>=0.3.1,<0.5',
-        'Shapely>=1.7.1',
+        'shapely',
     ],
     packages=find_packages(),
     zip_safe=False,


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>

@davidbrochart  - We need to add the dependency of shapely, as geopandas is the only dependency for building docs, hence docs build is not failing.
When I tested WKT functionality geopandas was already installed in my env hence it did not fail.
Now, when I created a new environment from scratch it fails as shapely is not added as a dependency. Hence adding it as a dependency.
