### PR TITLE
Add Map.fit_bounds(bounds)

### DIFF
--- a/docs/source/api_reference/map.rst
+++ b/docs/source/api_reference/map.rst
@@ -96,6 +96,7 @@ clear_layers                                                 Remove all layers f
 add_control        Control instance                          Add a new control to the map
 remove_control     Control instance                          Remove a control from the map
 clear_controls                                               Remove all controls from the map
-on_interaction     callable object                           Add a callback on interaction
-save               output file                               Save the map to an HTML file
+on_interaction     Callable object                           Add a callback on interaction
+save               Output file                               Save the map to an HTML file
+fit_bounds         Bounds                                    Set the map so that it contains the given bounds with the maximum zoom level.
 ================   =====================================     ===


### PR DESCRIPTION
It is not implemented using Leaflet's [fitBounds method](https://leafletjs.com/reference-1.7.1.html#map-fitbounds) (see issues below), but by iteratively changing the zoom level and checking the bounds (which is the maximum bounds of all map views).

Fixes #96 
Fixes #529 
