### PR TITLE
Added data attribute to DrawControl

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1661,6 +1661,9 @@ class DrawControl(Control):
     edit = Bool(True).tag(sync=True)
     remove = Bool(True).tag(sync=True)
 
+    # Layer data
+    data = List().tag(sync=True)
+
     last_draw = Dict({
         'type': 'Feature',
         'geometry': None


### PR DESCRIPTION
## Description

A data attribute is added to the model of the DrawControl widget. This allows the editable data layer to be changed programmatically from python. In addition, the attribute is automatically synced on each edit. The data attribute contains a
list dicts representing GeoJson objects. These are automatically converted into layers on the javascript side. It is possible to provide styling information by setting the property.style attribute.

The solution is not perfect as it does not give full control of the layers in the editable feature collection, but it does the job supporting many important use cases. In particular, it should solve issue #508.

This solution renders the DrawControl methods `clear`, `clear_polygons` obsolete.

## Demonstration code
```python
from ipyleaflet import Map, DrawControl

m = Map(center=[55.71937583528782, 13.13922374405463], zoom=10)
dc = DrawControl()
m += dc
dc.data = [{'type': 'Feature',
  'properties': {'style': {'stroke': True,
    'color': '#3388ff',
    'weight': 4,
    'opacity': 0.5,
    'fill': True,
    'fillColor': None,
    'fillOpacity': 0.2,
    'clickable': True}},
  'geometry': {'type': 'Polygon',
   'coordinates': [[[13.151797, 55.730145],
     [13.247946, 55.727439],
     [13.244512, 55.681398],
     [13.155918, 55.68372],
     [13.151797, 55.730145]]]}}]
display(m)
```

## References
This should solve issue #508

## Know issues
The way the style attribute is treated is a little bit sketchy. If you edit a provided shape, and then read the data again, typically extra style attributes are added. I am not sure how to fix this in the best way.





