### PR TITLE
Corrected fit_bounds docs

### DIFF
--- a/docs/source/api_reference/map.rst
+++ b/docs/source/api_reference/map.rst
@@ -98,5 +98,5 @@ remove_control     Control instance                          Remove a control fr
 clear_controls                                               Remove all controls from the map
 on_interaction     Callable object                           Add a callback on interaction
 save               Output file                               Save the map to an HTML file
-fit_bounds         Bounds                                    Set the map so that it contains the given bounds with the maximum zoom level.
+fit_bounds         Bounds                                    Set the map so that it contains the given bounds in the form [[south, west], [north, east]] with the maximum zoom level.
 ================   =====================================     ===

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -2245,7 +2245,7 @@ class Map(DOMWidget, InteractMixin):
         Parameters
         ----------
         bounds: list of lists
-            The lat/lon bounds in the form [[south, east], [north, west]].
+            The lat/lon bounds in the form [[south, west], [north, east]].
         """
         asyncio.ensure_future(self._fit_bounds(bounds))
 


### PR DESCRIPTION
The `fit_bounds` method documentation `[[south, east], [north, west]]` is incorrect. It should be `[[south, west], [north, east]]`