### PR TITLE
Declare LayerGroup view_module and model_module

### DIFF
--- a/js/src/layers/LayerGroup.js
+++ b/js/src/layers/LayerGroup.js
@@ -10,8 +10,10 @@ export class LeafletLayerGroupModel extends layer.LeafletLayerModel {
     return {
       _view_name: 'LeafletLayerGroupView',
       _model_name: 'LeafletLayerGroupModel',
-      _view_module: 'jupyter-leaflet',
       _model_module: 'jupyter-leaflet',
+      _model_module_version: null,
+      _view_module: 'jupyter-leaflet',
+      _view_module_version: null,
       layers: []
     };
   }

--- a/js/src/layers/LayerGroup.js
+++ b/js/src/layers/LayerGroup.js
@@ -10,6 +10,8 @@ export class LeafletLayerGroupModel extends layer.LeafletLayerModel {
     return {
       _view_name: 'LeafletLayerGroupView',
       _model_name: 'LeafletLayerGroupModel',
+      _view_module: 'jupyter-leaflet',
+      _model_module: 'jupyter-leaflet',
       layers: []
     };
   }


### PR DESCRIPTION
The `LayerGroup` was not inheriting the `_view_module` and `_model_module` from the super, which meant that the view and model could not be resolved in exported contexts. I'm guessing it was intentional not to call `...super.defaults()` to avoid inheriting a bunch of other attributes from the `LeafletLayerModel` but I'd love a confirmation of that from you @martinRenou.

Fixes https://github.com/jupyter-widgets/ipyleaflet/issues/811
Fixes https://github.com/jupyter-widgets/ipyleaflet/issues/761