### PR TITLE
Support GeoJson layer in MarkerCluster

### DIFF
--- a/examples/MarkerCluster-GeoJson.ipynb
+++ b/examples/MarkerCluster-GeoJson.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,33 +41,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f4da8a1aefb43e09ffd14c495da9bda",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[42.5, -41.6], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_ou…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = Map(center=(42.5, -41.6), zoom=2)\n",
     "m.add_layer(MarkerCluster(\n",
-    "    markers=(geojson_layer,), # The layer must be in a tuple\n",
+    "    markers=[geojson_layer], # The layer must be in a list or tuple\n",
     "    disable_clustering_at_zoom=3,\n",
     "    max_cluster_radius=100)\n",
     "    )\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Its possible to mix markers and geojson layers\n",
+    "mrk = [Marker(location=geolocation.coords[0][::-1]) for geolocation in cities.geometry]\n",
+    "\n",
+    "m = Map(center=(42.5, -41.6), zoom=2)\n",
+    "m.add_layer(MarkerCluster(\n",
+    "    markers=[geojson_layer] + mrk,\n",
+    "    disable_clustering_at_zoom=3,\n",
+    "    max_cluster_radius=100)\n",
+    "    )\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/MarkerCluster-GeoJson.ipynb
+++ b/examples/MarkerCluster-GeoJson.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import Map, Marker, MarkerCluster, GeoJSON, LayerGroup\n",
+    "import geopandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cities = geopandas.read_file(\"zip://./geopandas_cities.zip\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geojson = cities.__geo_interface__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geojson_layer = GeoJSON(data=geojson,\n",
+    "                        point_style={'radius': 5, 'color': 'red', 'fillOpacity': 0.8, 'fillColor': 'blue', 'weight': 3}\n",
+    "                       )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f4da8a1aefb43e09ffd14c495da9bda",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[42.5, -41.6], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_ou…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "m = Map(center=(42.5, -41.6), zoom=2)\n",
+    "m.add_layer(MarkerCluster(\n",
+    "    markers=(geojson_layer,), # The layer must be in a tuple\n",
+    "    disable_clustering_at_zoom=3,\n",
+    "    max_cluster_radius=100)\n",
+    "    )\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/MarkerCluster-GeoJson.ipynb
+++ b/examples/MarkerCluster-GeoJson.ipynb
@@ -2,17 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ipyleaflet import Map, Marker, MarkerCluster, GeoJSON, LayerGroup\n",
+    "from ipyleaflet import Map, Marker, MarkerCluster, GeoJSON, GeoData\n",
     "import geopandas"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1018,7 +1018,7 @@ class MarkerCluster(Layer):
     _view_name = Unicode('LeafletMarkerClusterView').tag(sync=True)
     _model_name = Unicode('LeafletMarkerClusterModel').tag(sync=True)
 
-    markers = Tuple().tag(trait=Instance(Marker), sync=True, **widget_serialization)
+    markers = Tuple().tag(trait=Instance(Layer), sync=True, **widget_serialization)
     # Options
     disable_clustering_at_zoom = Int(18).tag(sync=True, o=True)
     max_cluster_radius = Int(80).tag(sync=True, o=True)

--- a/js/src/layers/MarkerCluster.js
+++ b/js/src/layers/MarkerCluster.js
@@ -44,8 +44,6 @@ export class LeafletMarkerClusterView extends layer.LeafletLayerView {
   }
 
   add_layer_model(child_model) {
-    console.log(this.model.get('markers'));
-    console.log(child_model);
     return this.create_child_view(child_model, { map_view: this.map_view }).then(child_view => {
       this.obj.addLayer(child_view.obj);
       return child_view;


### PR DESCRIPTION
Initial PR (needs review, maybe tests...) addessing #881

Made it possible to use a GeoJson layer as the data source for Marker Cluster, this makes it much faster when creating large numbers of markers (but not having bidirectional sync on individual Marker widgets).

Implemented by copying the behaviour of LayerGroup, it will simply attempt to add the model of whatever is provided in the marker list to the marker group: **this allows to mix geojson and Marker elements**.