### PR TITLE
Added backward compatibility for dict basemaps

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -42,7 +42,7 @@ def basemap_to_tiles(basemap, day=yesterday, **kwargs):
 
     Parameters
     ----------
-    basemap : class:`xyzservices.lib.TileProvider`
+    basemap : class:`xyzservices.lib.TileProvider` or Dict
         Basemap description coming from ipyleaflet.basemaps.
     day: string
         If relevant for the chosen basemap, you can specify the day for
@@ -50,12 +50,18 @@ def basemap_to_tiles(basemap, day=yesterday, **kwargs):
     kwargs: key-word arguments
         Extra key-word arguments to pass to the TileLayer constructor.
     """
-    url = basemap.build_url(time=day, **kwargs)
+    if type(basemap) == xyzservices.lib.TileProvider:
+        url = basemap.build_url(time=day)
+    elif type(basemap) == dict:
+        url = basemap.get("url", "")
+    else:
+        raise ValueError("Invalid basemap type")
+
     return TileLayer(
         url=url,
         max_zoom=basemap.get('max_zoom', 19),
         min_zoom=basemap.get('min_zoom', 1),
-        attribution=basemap.get('html_attribution', ''),
+        attribution=basemap.get('html_attribution', '') or basemap.get('attribution', ''),
         name=basemap.get('name', ''),
         **kwargs
     )

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -50,9 +50,9 @@ def basemap_to_tiles(basemap, day=yesterday, **kwargs):
     kwargs: key-word arguments
         Extra key-word arguments to pass to the TileLayer constructor.
     """
-    if type(basemap) == xyzservices.lib.TileProvider:
+    if isinstance(basemap, xyzservices.lib.TileProvider):
         url = basemap.build_url(time=day)
-    elif type(basemap) == dict:
+    elif isinstance(basemap, dict):
         url = basemap.get("url", "")
     else:
         raise ValueError("Invalid basemap type")


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>

Hi @martinRenou,

I am not sure why these code changes were not included in my PR #857 . As these are there to handle backward compatibility with the dictionary for basemap_to_tiles function.
Please review this. Without this, it will break if the user passes a simple dictionary as a basemap.
I added these changes in my forked branch but somehow did not see them in the PR.
https://github.com/sackh/ipyleaflet/blob/b741cb5cf9e86ae5f62bd1408de391ae6300b353/ipyleaflet/leaflet.py#L53