### PR TITLE
Stop layer loading spinner when layer is removed

### DIFF
--- a/js/src/layers/TileLayer.js
+++ b/js/src/layers/TileLayer.js
@@ -52,6 +52,11 @@ export class LeafletTileLayerView extends rasterlayer.LeafletRasterLayerView {
         this.spinner.stop();
       }
     });
+    this.obj.on("remove", event => {
+      if (this.model.get('show_loading')) {
+        this.spinner.stop();
+      }
+    })
   }
 
   model_events() {


### PR DESCRIPTION
This fixes a problem where if `show_loading` is `True` for a layer, and this layer is removed from the map prior to all tiles being loaded, the loading spinner for this layer continues to spin and is stuck on the map indefinitely.

It is noted that this tends to only be a problem for layers that take a good amount of time to load. Otherwise, under practical circumstances, it is unlikely that a layer `remove` event would fire before the `load` event. Therefore, to reproduce the problem described above, you will either need to find a tile layer that is slow to load, or otherwise temporarily disable the bit of code that stops the loading spinner upon the `load` event.

(Also, this is my first contribution here! If I should be opening an issue or something like that, let me know!)