### PR TITLE
Remove map callbacks when DrawControl removed from map

### DIFF
--- a/js/src/controls/DrawControl.js
+++ b/js/src/controls/DrawControl.js
@@ -127,6 +127,8 @@ export class LeafletDrawControlView extends control.LeafletControlView {
     this.map_view.obj.off('draw:created');
     this.map_view.obj.off('draw:edited');
     this.map_view.obj.off('draw:deleted');
+    this.model.off('msg:custom');
+    this.model.off('change:data');
   }
 
   data_to_layers() {

--- a/js/src/controls/DrawControl.js
+++ b/js/src/controls/DrawControl.js
@@ -122,6 +122,13 @@ export class LeafletDrawControlView extends control.LeafletControlView {
     this.model.on('change:data', this.data_to_layers.bind(this));
   }
 
+  remove() {
+    this.map_view.obj.removeLayer(this.feature_group);
+    this.map_view.obj.off('draw:created');
+    this.map_view.obj.off('draw:edited');
+    this.map_view.obj.off('draw:deleted');
+  }
+
   data_to_layers() {
     const data = this.model.get('data');
     this.feature_group.clearLayers();
@@ -181,5 +188,6 @@ export class LeafletDrawControlView extends control.LeafletControlView {
         }
       });
     }
+    this.layers_to_data()
   }
 }


### PR DESCRIPTION
This fixes a bug wherein if a DrawControl is added and removed from a Map several times, callbacks start accumulating, resulting in duplicate layers.

For example, the following adds a DrawControl to the map, and adds a polygon to it:

```python
from ipyleaflet import Map, DrawControl
m = Map()
dc = DrawControl()
dc.data = [{
    'type': 'Feature',
    'properties': {
        'style': {
            'stroke': True,
            'color': '#3388ff',
            'weight': 4,
            'opacity': 0.5,
            'fill': True,
            'fillColor': None,
            'fillOpacity': 0.2,
            'clickable': True
        }
    },
    'geometry': {
        'type': 'Polygon',
        'coordinates': [
            [[-0.104027, 0.005665],
             [-0.069351, 0.023518],
             [-0.062141, 0.00103],
             [-0.104027, 0.005665]]
        ]
    }
}]
m.add_control(dc)
m
```

Now, by removing and adding the DrawControl several times, we can see that it becomes much darker in opacity, which is due to the same layer getting re-added to the map:

```python
for i in range(10):
    m.remove_control(dc)
    m.add_control(dc)
```

Additionally, if we clear the DrawControl, and remove and add it again, we can observe it leaves behind a "ghost" polygon that we previously cleared:

```python
dc.clear()
m.remove_control(dc)
m.add_control(dc)
```

This "ghost" disappears when we start drawing more Polygons, it appears to be the result of not updating the DrawControl model after updating the view.

Two additional callbacks appear to get added each time the DrawControl is added to the Map which I did not attempt to address:
```javascript
this.model.on('msg:custom', this.handle_message.bind(this));
this.model.on('change:data', this.data_to_layers.bind(this));
```
Although I _think_ they can probably be removed when the DrawControl is removed from the map too?