### PR TITLE
Updates on ipyleaflet documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
+conda:
+  environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,20 @@
+name: ipyleaflet-docs
+
+channels:
+  - conda-forge
+
+dependencies:
+  - yarn
+  - jupyterlab
+  - jupyter-packaging
+  - jupyter-sphinx
+  - scipy
+  - netcdf4
+  - geopandas
+  - xarray
+  - branca
+  - shapely
+  - pip:
+    - ..
+    
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,0 @@
-ipyleaflet
-jupyter-sphinx==0.2.4a1
-scipy
-netcdf4
-geopandas
-xarray
-branca
-shapely

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,5 @@
+API Reference
+----------
+
+.. automodule:: ipyleaflet.leaflet
+   :members:

--- a/docs/source/api_reference/antpath.rst
+++ b/docs/source/api_reference/antpath.rst
@@ -55,17 +55,5 @@ Like most widgets in ipyleaflet, the ``AntPath`` can be dynamically updated from
 Attributes
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-locations                []                      List of path points as (lat, lng) couples
-color                    '#0000FF'               Background color for the path
-pulse_color              '#FFFFFF'               Color of the moving ants on the path
-paused                   False                   Whether the ants are moving or not
-reverse                  False                   Whether the ants are moving in reverse or not
-use                      'polyline'              Which shape is drawn, possible values are 'polyline', 'polygon', 'rectangle' and 'circle'
-dash_array               [10, 20]                Dash pattern for lines as a list of non-negative numbers
-weight                   5                       Lines weight
-delay                    400                     Ants speed
-radius                   10                      Radius of the circle, if ``use`` is set to 'circle'
-=====================    =====================   ===
+.. autoclass:: ipyleaflet.leaflet.AntPath
+   :members:

--- a/docs/source/api_reference/awesome_icon.rst
+++ b/docs/source/api_reference/awesome_icon.rst
@@ -54,11 +54,5 @@ Unlike other widgets in ipyleaflet, the ``AwesomeIcon`` widget is not dynamic. I
 Attributes
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-name                     'home'                  Name of the Font-Awesome icon
-marker_color             'blue'                  Marker background color
-icon_color               'white'                 Icon color
-spin                     False                   Whether the icon is spinning or not
-=====================    =====================   ===
+.. autoclass:: ipyleaflet.leaflet.AwesomeIcon
+   :members:

--- a/docs/source/api_reference/choropleth.rst
+++ b/docs/source/api_reference/choropleth.rst
@@ -91,16 +91,5 @@ The ``Choropleth`` layer is then created specifying on which key the colormap is
 Attributes
 ----------
 
-==============   ==========================  ===========
-Attribute        Default                     Doc
-==============   ==========================  ===========
-geo_data         {}                          Data dictionary
-choro_data       {}                          Mapping key -> float data for constructing the colormap
-key_on           'id'                        Key used for the colormap construction
-value_min                                    Color scale minimum value
-value_max                                    Color scale maximum value
-colormap         OrRd_06                     Map of color from branca
-style                                        Style dictionary
-hover_style                                  Hover style dictionary
-style_callback                               Styling function that is called for each feature, and should return the feature style. This styling function takes the feature, the colormap function and the key data as arguments.
-==============   ==========================  ===========
+.. autoclass:: ipyleaflet.leaflet.Choropleth
+   :members:

--- a/docs/source/api_reference/circle.rst
+++ b/docs/source/api_reference/circle.rst
@@ -26,19 +26,5 @@ Example
 Attributes
 ----------
 
-==============    ================   ===
-Attribute         Default Value      Doc
-==============    ================   ===
-location          (0.0, 0.0)         Circle location
-radius            10                 Circle radius in meters
-stroke            True               Set it to `false` to disable borders
-color             "#0033FF"          Stroke color
-opacity           1.0                Stroke opacity
-weight            5                  Stroke width in pixels
-fill              True               Whether to fill the circle or not
-fill_color        None
-fill_opacity      0.2
-dash_array
-line_cap          "round"
-line_join         "round"
-==============    ================   ===
+.. autoclass:: ipyleaflet.leaflet.Circle
+   :members:

--- a/docs/source/api_reference/circle_marker.rst
+++ b/docs/source/api_reference/circle_marker.rst
@@ -26,19 +26,5 @@ Example
 Attributes
 ----------
 
-==============    ================   ===
-Attribute         Default Value      Doc
-==============    ================   ===
-location          (0.0, 0.0)         Circle location
-radius            10                 Circle radius in pixels
-stroke            True               Set it to `false` to disable borders
-color             "#0033FF"          Stroke color
-opacity           1.0                Stroke opacity
-weight            5                  Stroke width in pixels
-fill              True               Whether to fill the circle or not
-fill_color        None
-fill_opacity      0.2
-dash_array
-line_cap          "round"
-line_join         "round"
-==============    ================   ===
+.. autoclass:: ipyleaflet.leaflet.CircleMarker
+   :members:

--- a/docs/source/api_reference/divicon.rst
+++ b/docs/source/api_reference/divicon.rst
@@ -21,12 +21,5 @@ Example
 Attributes
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-html                     ''                      Custom HTML code to put inside the div element,
-bg_pos                   (0, 0)                  Optional relative position of the background, in pixels.
-icon_size                (10, 10)                size icon will be rendered
-icon_anchor              (0, 0)                  anchor point of icon
-popup_anchor             (0, 0)                  anchor point of popup
-=====================    =====================   ===
+.. autoclass:: ipyleaflet.leaflet.DivIcon
+   :members:

--- a/docs/source/api_reference/draw_control.rst
+++ b/docs/source/api_reference/draw_control.rst
@@ -3,6 +3,8 @@ Draw Control
 
 The ``DrawControl`` allows one to draw shapes on the map such as ``Rectangle`` ``Circle`` or lines.
 
+Example
+-------
 .. jupyter-execute::
 
     from ipyleaflet import Map, basemaps, basemap_to_tiles, DrawControl

--- a/docs/source/api_reference/fullscreen_control.rst
+++ b/docs/source/api_reference/fullscreen_control.rst
@@ -13,9 +13,8 @@ Example
 
     m
 
+Attribute
+-------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.FullScreenControl
+   :members:

--- a/docs/source/api_reference/geo_json.rst
+++ b/docs/source/api_reference/geo_json.rst
@@ -56,24 +56,9 @@ The ``GeoJSON`` layer is a widget, which means that you can update the ``data`` 
     geo_json.hover_style = new_hover_style
 
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
-==============   ===
-Attribute        Doc
-==============   ===
-data             Data dictionary
-style            Style dictionary
-hover_style      Hover style dictionary
-style_callback   Styling function that is called for each feature, and should return the feature style. This styling function takes the feature as argument.
-==============   ===
+.. autoclass:: ipyleaflet.leaflet.GeoJSON
+   :members:
 
-Methods
--------
-
-=========    =====================================     ===
-Method       Arguments                                 Doc
-=========    =====================================     ===
-on_click     Callable object                           Adds a callback on click event
-on_hover     Callable object                           Adds a callback on hover event
-=========    =====================================     ===

--- a/docs/source/api_reference/geodata.rst
+++ b/docs/source/api_reference/geodata.rst
@@ -62,11 +62,5 @@ Points example:
 Attributes
 ----------
 
-============   ==========================  ===========
-Attribute      Doc                         Description
-============   ==========================  ===========
-geo_data       Data dictionary             GeoDataFrame
-style          Style dictionary
-hover_style    Hover style dictionary
-point_style    Point decorations           Used to represent point data on the map as CircleMarkers.  If absent, points will be represented by Markers.
-============   ==========================  ===========
+.. autoclass:: ipyleaflet.leaflet.GeoData
+   :members:

--- a/docs/source/api_reference/heatmap.rst
+++ b/docs/source/api_reference/heatmap.rst
@@ -23,15 +23,6 @@ Example
 Attributes
 ----------
 
-==============    ===================================================================    ====
-Attribute         Default Value                                                          Doc
-==============    ===================================================================    ====
-locations         []                                                                     List of center locations
-min_opacity       0.05                                                                   Minimum opacity the heat will start at
-max_zoom          18                                                                     Zoom level where max intensity is reached
-max               1.0                                                                    Maximum point intensity
-radius            25.0                                                                   Radius of each "point" of the heatmap
-blur              15.0                                                                   Amount of blur
-gradient          {0.4: 'blue', 0.6: 'cyan', 0.7: 'lime', 0.8: 'yellow', 1.0: 'red'}     Color gradient config
-==============    ===================================================================    ====
+.. autoclass:: ipyleaflet.leaflet.Heatmap
+   :members:
 

--- a/docs/source/api_reference/icon.rst
+++ b/docs/source/api_reference/icon.rst
@@ -21,14 +21,5 @@ Example
 Attributes
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-icon_url                 ''                      url for icon
-shadow_url               None                    url for icon shadow
-icon_size                (10, 10)                size icon will be rendered
-shadow_size              (10, 10)                size icon shadow will be rendered
-icon_anchor              (0, 0)                  anchor point of icon
-shadow_anchor            (0, 0)                  anchor point of shadow
-popup_anchor             (0, 0)                  anchor point of popup
-=====================    =====================   ===
+.. autoclass:: ipyleaflet.leaflet.Icon
+   :members:

--- a/docs/source/api_reference/image_video_overlay.rst
+++ b/docs/source/api_reference/image_video_overlay.rst
@@ -41,9 +41,5 @@ Example VideoOverlay
 Attributes
 ----------
 
-===========    ========================   ===
-Attribute      Default Value              Doc
-===========    ========================   ===
-url            ""                         An http url to the footage or a relative path to a local file (image/video). Note that absolute local paths are not supported. 
-bounds         ((0.0, 0.0), (0.0, 0.0))   SW and NE corners of the image
-===========    ========================   ===
+.. autoclass:: ipyleaflet.leaflet.VideoOverlay
+   :members:

--- a/docs/source/api_reference/layer_group.rst
+++ b/docs/source/api_reference/layer_group.rst
@@ -35,19 +35,5 @@ Example
 Attributes
 ----------
 
-==============    ================   ===
-Attribute         Default Value      Doc
-==============    ================   ===
-layers            ()                 List of layers
-==============    ================   ===
-
-Methods
--------
-
-==============    =====================================     ===
-Method            Arguments                                 Doc
-==============    =====================================     ===
-add_layer         Layer instance                            Add a new layer to the group
-remove_layer      Layer instance                            Remove a layer from the group
-clear_layers                                                Remove all layers from the group
-==============    =====================================     ===
+.. autoclass:: ipyleaflet.leaflet.LayerGroup
+   :members:

--- a/docs/source/api_reference/layers_control.rst
+++ b/docs/source/api_reference/layers_control.rst
@@ -1,11 +1,16 @@
 Layers Control
 ==============
 
+
+
 The ``LayersControl`` allows one to display a layer selector on the map in order
 to select which layers to display on the map.
 
 All layers have a ``name`` attribute which is displayed in the selector and can be changed
 by the user.
+
+Example
+-------
 
 .. jupyter-execute::
 
@@ -24,3 +29,4 @@ by the user.
     m.add_control(control)
 
     m
+

--- a/docs/source/api_reference/legend_control.rst
+++ b/docs/source/api_reference/legend_control.rst
@@ -37,10 +37,5 @@ Example
 Attributes
 ----------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-legend              None               A dictionary containing the name->color mapping that represents the legend
-title               'Legend'           Legend name
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.LegendControl
+   :members:

--- a/docs/source/api_reference/local_tile_layer.rst
+++ b/docs/source/api_reference/local_tile_layer.rst
@@ -22,8 +22,5 @@ In JupyterLab, the path is relative to the server (where you started JupyterLab)
 Attributes
 ----------
 
-===============    =================  =====
-Attribute          Default Value      Doc
-===============    =================  =====
-path               ""                 Relative URL (e.g. 'tiles/{z}/{x}/{y}.png' or 'files/tiles/{z}/{x}/{y}.png' in JupyterLab)
-===============    =================  =====
+.. autoclass:: ipyleaflet.leaflet.LocalTileLayer
+   :members:

--- a/docs/source/api_reference/magnifying_glass.rst
+++ b/docs/source/api_reference/magnifying_glass.rst
@@ -20,13 +20,5 @@ Example
 Attributes
 ----------
 
-==============    ===================================================================    ====
-Attribute         Default Value                                                          Doc
-==============    ===================================================================    ====
-radius            100                                                                    Radius of the magnifying glass in pixels.
-zoom_offset       3                                                                      Zoom level offset between the main map zoom and the magnifying glass.
-fixed_zoom        -1                                                                     Fixed zoom level to always use (if different than -1).
-fixed_position    False                                                                  If True, the magnifying glass will stay at the same position.
-lat_lng           [0, 0]                                                                 Initial position of the magnifying glass.
-layers            []                                                                     Set of layers to display in the magnified view.
-==============    ===================================================================    ====
+.. autoclass:: ipyleaflet.leaflet.MagnifyingGlass
+   :members:

--- a/docs/source/api_reference/map.rst
+++ b/docs/source/api_reference/map.rst
@@ -1,7 +1,7 @@
 Map
 ===
 
-Usage
+Example
 -----
 
 .. jupyter-execute::
@@ -15,7 +15,9 @@ Usage
     )
 
     m
-
+    
+Usage
+-----
 You can find the list of available basemaps in the :ref:`basemaps-section` page.
 
 You can add multiple layers and controls to the map, using the ``add_layer``/``add_control`` methods. All those layers and controls are widgets themselves. So you can dynamically update their attributes from Python or by interacting with the map on the page (see :ref:`usage-section`)
@@ -65,56 +67,9 @@ You can save the ``Map`` and all its layers and controls to an HTML page using t
     The saved file is a static HTML page, so there is no possible interaction with Python anymore. This means that all the Python callbacks you defined (`e.g.` on marker move) cannot be executed. If you want to serve the ``Map`` widget to an HTML page while keeping a Python kernel alive on the server, you might want to look at `Voilà <https://voila.readthedocs.io>`_.
 
 
-Attributes
+Attributes and methods
 ----------
 
-========================    =====================               ===
-Attribute                   Default Value                       Doc
-========================    =====================               ===
-layers                      (default_layer)                     Tuple of layers
-controls                    ()                                  Tuple of controls
-center                      (0.0, 0.0)                          Initial geographic center of the map
-zoom                        12                                  Initial map zoom level
-max_zoom                    18
-min_zoom                    1
-zoom_snap                   1                                   Forces the map's zoom level to always be a multiple of this
-zoom_delta                  1                                   Controls how much the map's zoom level will change after pressing + or - on the keyboard, or using the zoom controls
-crs                         projections.EPSG3857                Coordinate reference system, which can be 'Earth', 'EPSG3395', 'EPSG3857', 'EPSG4326', 'Base', 'Simple' or you can define your own projection. (See CustomProjections notebook)
-dragging                    True                                Whether the map be draggable with mouse/touch or not
-touch_zoom                  True                                Whether the map can be zoomed by touch-dragging with two fingers on mobile
-scroll_wheel_zoom           False                               Whether the map can be zoomed by using the mouse wheel
-double_click_zoom           True                                Whether the map can be zoomed in by double clicking on it and zoomed out by double clicking while holding shift
-box_zoom                    True                                Whether the map can be zoomed to a rectangular area specified by dragging the mouse while pressing the shift key
-tap                         True                                Enables mobile hacks for supporting instant taps
-tap_tolerance               15                                  The max number of pixels a user can shift his finger during touch for it to be considered a valid tap
-world_copy_jump             False                               With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to
-close_popup_on_click        True                                Set it to False if you don't want popups to close when user clicks the map
-bounce_at_zoom_limits       True                                Set it to False if you don't want the map to zoom beyond min/max zoom and then bounce back when pinch-zooming
-keyboard                    True                                Makes the map focusable and allows users to navigate the map with keyboard arrows and +/- keys
-keyboard_pan_offset         80
-keyboard_zoom_offset        1
-inertia                     True                                If enabled, panning of the map will have an inertia effect
-inertia_deceleration        3000                                The rate with which the inertial movement slows down, in pixels/second²
-inertia_max_speed           1500                                Max speed of the inertial movement, in pixels/second
-zoom_control                True
-attribution_control         True
-zoom_animation_threshold    4
-========================    =====================               ===
+.. autoclass:: ipyleaflet.Map
+   :members:
 
-Methods
--------
-
-================   =====================================     ===
-Method             Arguments                                 Doc
-================   =====================================     ===
-add_layer          Layer instance                            Add a new layer to the map
-remove_layer       Layer instance                            Remove a layer from the map
-substitute_layer   Layer instance                            Substitute a layer with a new layer
-clear_layers                                                 Remove all layers from the map
-add_control        Control instance                          Add a new control to the map
-remove_control     Control instance                          Remove a control from the map
-clear_controls                                               Remove all controls from the map
-on_interaction     Callable object                           Add a callback on interaction
-save               Output file                               Save the map to an HTML file
-fit_bounds         Bounds                                    Set the map so that it contains the given bounds in the form [[south, west], [north, east]] with the maximum zoom level.
-================   =====================================     ===

--- a/docs/source/api_reference/marker.rst
+++ b/docs/source/api_reference/marker.rst
@@ -18,32 +18,8 @@ Example
     m
 
 
-Attributes
+Attributes and methods
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-location                 (0.0, 0.0)
-z_index_offset           0
-draggable                True                    Whether the marker is draggable with mouse/touch or not
-keyboard                 True                    Whether the marker can be tabbed to with a keyboard and clicked by pressing enter
-title                    ""                      Text for the browser tooltip that appear on marker hover (no tooltip by default)
-alt                      ""                      Text for the `alt` attribute of the icon image (useful for accessibility)
-rise_on_hover            False                   The z-index offset used for the `rise_on_hover` feature
-opacity                  1.0
-visible                  True
-rise_offset              250                     The z-index offset used for the `rise_on_hover` feature
-rotation_angle           0                       The rotation angle of the marker in degrees
-rotation_origin          'bottom center'         The rotation origin of the marker
-icon                     None                    The icon for the marker
-=====================    =====================   ===
-
-Methods
--------
-
-==========    =====================================     ===
-Method        Arguments                                 Doc
-==========    =====================================     ===
-on_move       Callable object                           Adds a callback on move event
-==========    =====================================     ===
+.. autoclass:: ipyleaflet.leaflet.Marker
+   :members:

--- a/docs/source/api_reference/marker_cluster.rst
+++ b/docs/source/api_reference/marker_cluster.rst
@@ -26,8 +26,5 @@ Example
 Attributes
 ----------
 
-============   ================   ===
-Attribute      Default Value      Doc
-============   ================   ===
-markers        ()                 Tuple of markers
-============   ================   ===
+.. autoclass:: ipyleaflet.leaflet.MarkerCluster
+   :members:

--- a/docs/source/api_reference/measure_control.rst
+++ b/docs/source/api_reference/measure_control.rst
@@ -28,29 +28,8 @@ Example
     m
 
 
-Attributes
+Attributes and methods
 ----------
 
-=====================    ==========================================================================   ===
-Attribute                Default Value                                                                Doc
-=====================    ==========================================================================   ===
-position                 "topright"                                                                   Position of the control on the Map, possible values are topleft, topright, bottomleft or bottomright
-primary_length_unit      "feet"                                                                       Primary length unit, possible values are feet, meters, miles, kilometers or any user defined length unit
-secondary_length_unit    None                                                                         Secondary length unit, possible values are None, feet, meters, miles, kilometers or any user defined length unit
-primary_area_unit        "acres"                                                                      Primary area unit, possible values are acres, hectares, sqfeet, sqmeters, sqmiles or any user defined area unit
-secondary_area_unit      None                                                                         Secondary area unit, possible values are None, acres, hectares, sqfeet, sqmeters, sqmiles or any user defined area unit
-active_color             "#ABE67E"                                                                    Color of the currently drawn area
-completed_color          "#C8F2BE"                                                                    Color of the completed areas
-popup_options            {'className': 'leaflet-measure-resultpopup', 'autoPanPadding': [10, 10]}
-capture_z_index          10000                                                                        Z-index of the marker used to capture measure clicks. Set this value higher than the z-index of all other map layers to disable click events on other layers while a measurement is active.
-=====================    ==========================================================================   ===
-
-Methods
--------
-
-=================    =====================================     ===
-Method               Arguments                                 Doc
-=================    =====================================     ===
-add_length_unit      name, factor, decimals=0                  Adds a length unit with a name, a factor (factor to apply when converting to this unit. Length in meters will be multiplied by this factor), and an optional number of displayed decimals
-add_area_unit        name, factor, decimals=0                  Adds a area unit with a name, a factor (factor to apply when converting to this unit. Area in sqmeters will be multiplied by this factor), and an optional number of displayed decimals
-=================    =====================================     ===
+.. autoclass:: ipyleaflet.leaflet.MeasureControl
+   :members:

--- a/docs/source/api_reference/polygon.rst
+++ b/docs/source/api_reference/polygon.rst
@@ -1,10 +1,11 @@
 Polygon/Multipolygon
 ====================
 
-Polygon
--------
 
+Example Polygon
+------------------
 You can easily create a ``Polygon`` providing the list of vertex locations (in lat/lng).
+
 
 .. jupyter-execute::
 
@@ -23,7 +24,7 @@ You can easily create a ``Polygon`` providing the list of vertex locations (in l
 
 Because the ``Polygon`` an interactive widget, you can dynamically update the locations/color from Python, and you will see updated on the ``Map``.
 
-Polygon with holes
+Example Polygon with holes
 ------------------
 
 You can define holes in your ``Polygon`` by using nested lists of vertex locations.
@@ -47,7 +48,7 @@ You can define holes in your ``Polygon`` by using nested lists of vertex locatio
     m
 
 
-MultiPolygon
+Example MultiPolygon
 ------------
 
 .. jupyter-execute::
@@ -69,7 +70,7 @@ MultiPolygon
     m
 
 
-Editable Polygon
+Example Editable Polygon
 ----------------
 
 If ``transform`` is set to ``True``, you can dynamically edit the polygon with the mouse.
@@ -94,22 +95,5 @@ If ``transform`` is set to ``True``, you can dynamically edit the polygon with t
 Attributes
 ----------
 
-===============  ================   ===
-Attribute        Default Value      Doc
-===============  ================   ===
-locations        []                 List of points of the polygon
-stroke           True               Set it to `False` to disable borders
-color            "#0033FF"          Stroke color
-opacity          1.0                Stroke opacity
-weight           5                  Stroke width in pixels
-fill             True               Whether to fill the polygon or not
-fill_color       None               If None, it will be the same as the color value
-fill_opacity     0.2
-dash_array
-line_cap         "round"
-line_join        "round"
-transform        False              Whether the polygon is editable with the mouse or not
-scaling          True               Whether the polygon scale is editable or not, needs transform set to ``True``
-rotation         True               Whether the polygon rotation is editable or not, needs transform set to ``True``
-uniform_scaling  False              Whether to keep the scale ratio when editing the scale, needs transform set to ``True``
-===============  ================   ===
+.. autoclass:: ipyleaflet.leaflet.Polygon
+   :members:

--- a/docs/source/api_reference/polyline.rst
+++ b/docs/source/api_reference/polyline.rst
@@ -52,18 +52,5 @@ Example MultiPolyline
 Attributes
 ----------
 
-=============    ================   ===
-Attribute        Default Value      Doc
-=============    ================   ===
-locations        [[]]               List of list of points of the polygon
-stroke           True               Set it to `False` to disable borders
-color            "#0033FF"          Stroke color
-opacity          1.0                Stroke opacity
-weight           5                  Stroke width in pixels
-fill             True               Whether to fill the polyline or not
-fill_color       None
-fill_opacity     0.2
-dash_array
-line_cap         "round"
-line_join        "round"
-=============    ================   ===
+.. autoclass:: ipyleaflet.leaflet.Polyline
+   :members:

--- a/docs/source/api_reference/popup.rst
+++ b/docs/source/api_reference/popup.rst
@@ -43,17 +43,5 @@ Example
 Attributes
 ----------
 
-=====================    =====================   ===
-Attribute                Default Value           Doc
-=====================    =====================   ===
-location                 (0.0, 0.0)
-child                                            Content of the popup
-max_width                300                     Max width of the popup, in pixels
-min_width                50                      Min width of the popup, in pixels
-max_height                                       If set, creates a scrollable container of the given height inside a popup if its content exceeds it
-auto_pan                 True                    Set it to `False` if you don't want the map to do panning animation to fit the opened popup
-auto_pan_padding         (5, 5)
-keep_in_view             False                   Set it to `True` if you want to prevent users from panning the popup off of the screen while it is open
-close_button             True                    Controls the presence of a close button in the popup
-close_on_escape_key      True                    Set it to `False` if you want to override the default behavior of the ESC key for closing of the popup
-=====================    =====================   ===
+.. autoclass:: ipyleaflet.leaflet.Popup
+   :members:

--- a/docs/source/api_reference/rectangle.rst
+++ b/docs/source/api_reference/rectangle.rst
@@ -22,18 +22,5 @@ Example
 Attributes
 ----------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-bounds              ()                 SW and NE corners of the rectangle
-stroke              True               Set it to `False` to disable borders
-color               "#0033FF"          Stroke color
-opacity             1.0                Stroke opacity
-weight              5                  Stroke width in pixels
-fill                True               Whether to fill the polygon or not
-fill_color          None
-fill_opacity        0.2
-dash_array
-line_cap            "round"
-line_join           "round"
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.Rectangle
+   :members:

--- a/docs/source/api_reference/scale_control.rst
+++ b/docs/source/api_reference/scale_control.rst
@@ -17,12 +17,5 @@ Example
 Attributes
 ----------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-max_width           100                Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).
-metric              True               Whether to show the metric scale line (m/km).
-imperial            True               Whether to show the imperial scale line (mi/ft).
-update_when_idle    False              If true, the control is updated only after ending dragging the Map, otherwise it's always up-to-date (updated during move).
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.ScaleControl
+   :members:

--- a/docs/source/api_reference/search_control.rst
+++ b/docs/source/api_reference/search_control.rst
@@ -78,26 +78,10 @@ You can also search features from GeoJSON layers.
 
     m
 
-Attributes
+Methods
 ----------
 
-================    ======================================  ===
-Attribute           Default Value                           Doc
-================    ======================================  ===
-position            'topleft'                               Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-url                 ''                                      The url used for the search queries.
-layer               None                                    The LayerGroup used for search queries.
-zoom                None                                    The zoom level after moving to searched location, by default zoom level will not change.
-marker              Marker()                                The marker used by the control.
-found_style         {'fillColor': '#3f0', 'color': '#0f0'}  Style for searched feature when searching in LayerGroup.
-================    ======================================  ===
+.. autoclass:: ipyleaflet.leaflet.SearchControl
+   :members:
 
-Methods
--------
 
-==================     =====================================     ===
-Method                 Arguments                                 Doc
-==================     =====================================     ===
-on_location_found      Callable object                           Adds a callback on location found event.
-on_feature_found       Callable object                           Adds a callback on found event for searching in GeoJSON layer.
-==================     =====================================     ===

--- a/docs/source/api_reference/split_map_control.rst
+++ b/docs/source/api_reference/split_map_control.rst
@@ -22,9 +22,5 @@ Example
 Attributes
 ----------
 
-=====================   ========================================    ================   ===
-Attribute               Type                                        Default Value      Doc
-=====================   ========================================    ================   ===
-left_layer              Layer instance                                                 Left layer
-right_layer             Layer instance                                                 Right layer
-=====================   ========================================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.SplitMapControl
+   :members:

--- a/docs/source/api_reference/tile_layer.rst
+++ b/docs/source/api_reference/tile_layer.rst
@@ -31,24 +31,9 @@ Sometimes one could want to specify the date of the given images, for instance w
     nasa_layer = basemap_to_tiles(basemaps.NASAGIBS.ModisTerraTrueColorCR, "2018-04-08");
     m.add_layer(nasa_layer);
 
-Attributes
+Attributes and methods
 ----------
 
-===============    ===================================================================================
-Attribute          Default Value
-===============    ===================================================================================
-url                "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-min_zoom           0
-max_zoom           18
-min_native_zoom    0
-max_native_zoom    18
-bounds             None
-tile_size          256
-attribution        "Map data (c) <a href=\'https://openstreetmap.org\'>OpenStreetMap</a> contributors"
-detect_retina      False
-opacity            1.0
-visible            True
-no_wrap            False
-show_loading       False
-loading            False (dynamically updated)
-===============    ===================================================================================
+.. autoclass:: ipyleaflet.leaflet.TileLayer
+   :members:
+

--- a/docs/source/api_reference/vector_tile.rst
+++ b/docs/source/api_reference/vector_tile.rst
@@ -141,10 +141,5 @@ Example
 Attributes
 ----------
 
-=========================    =================================================================================     =====================================================
-Attribute                    Default Value                                                                         Doc
-=========================    =================================================================================     =====================================================
-url                          ''                                                                                    Url for the source protobuf data.
-attribution                  'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors'     Attribution for the map.
-vector_tile_layer_styles     {}                                                                                    Styles for the various data layer of protobuf layers.
-=========================    =================================================================================     =====================================================
+.. autoclass:: ipyleaflet.leaflet.VectorTileLayer
+   :members:

--- a/docs/source/api_reference/velocity.rst
+++ b/docs/source/api_reference/velocity.rst
@@ -45,20 +45,5 @@ Example
 Attributes
 ----------
 
-
-======================    ===================================================================    ====
-Attribute                 Default Value                                                          Doc
-======================    ===================================================================    ====
-data                      Empty dataset                                                          Underlying dataset
-zonal_speed               ''                                                                     Variable name in underlying dataset for the zonal speed
-meridional_speed          ''                                                                     Variable name in underlying dataset for the meridional speed
-latitude_dimension        'latitude'                                                             Name of the latitude dimension in underlying dataset
-longitude_dimension       'longitude'                                                            Name of the longitude dimension in underlying dataset
-units                     None                                                                   Units
-display_values            True                                                                   Display velocity data on mouse hover
-display_options           {}                                                                     Display options
-min_velocity              0.0                                                                    Used to align color scale
-max_velocity              10.0                                                                   Used to align color scale
-velocity_scale            0.005                                                                  Modifier for particle animations
-color_scale               []                                                                     Array of hex/rgb colors for user-specified color scale.
-======================    ===================================================================    ====
+.. autoclass:: ipyleaflet.velocity.Velocity
+   :members:

--- a/docs/source/api_reference/widget_control.rst
+++ b/docs/source/api_reference/widget_control.rst
@@ -24,14 +24,5 @@ Example
 Attributes
 ----------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-widget              None               Widget content
-min_width           None               Min width of the widget (in pixels), if None it will respect the content size
-max_width           None               Max width of the widget (in pixels), if None it will respect the content size
-min_height          None               Min height of the widget (in pixels), if None it will respect the content size
-max_height          None               Max height of the widget (in pixels), if None it will respect the content size
-transparent_bg      False              If set to True will make the widget background transparent
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.WidgetControl
+   :members:

--- a/docs/source/api_reference/wkt_layer.rst
+++ b/docs/source/api_reference/wkt_layer.rst
@@ -46,9 +46,5 @@ You can also provide WKT string as input.
 Attributes
 ----------
 
-============   ==========================  ===========
-Attribute      Default Value               Doc
-============   ==========================  ===========
-path           ''                          Local path of WKT file
-wkt_string     ''                          WKT string
-============   ==========================  ===========
+.. autoclass:: ipyleaflet.leaflet.WKTLayer
+   :members:

--- a/docs/source/api_reference/wms_layer.rst
+++ b/docs/source/api_reference/wms_layer.rst
@@ -22,8 +22,8 @@ Example
 
     m
 
-Advanced usage
---------------
+Usage
+-----
 
 By default, options like ``layers``, ``format``, ``transparent`` are passed in the request URL. If your tiles provider needs
 any extra parameter, you can define your own ``WMSLayer`` class which adds new parameters. For example, the following code
@@ -88,20 +88,5 @@ Or from another widget like a slider: (Note that this example will not work in t
 Attributes
 ----------
 
-===============   ===================================================================================   ===
-Attribute         Default Value                                                                         Doc
-===============   ===================================================================================   ===
-url               "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-min_zoom          0
-max_zoom          18
-tile_size         256
-attribution       "Map data (c) <a href=\'https://openstreetmap.org\'>OpenStreetMap</a> contributors"
-detect_retina     False
-opacity           1.0
-visible           True
-layers            ""                                                                                    Comma-separated list of WMS layers to show
-styles            ""                                                                                    Comma-separated list of WMS styles
-format            "image/jpeg"                                                                          WMS image format (use `'image/png'` for layers with transparency)
-transparent       False                                                                                 If `True`, the WMS service will return images with transparency
-crs               ipyleaflet.projections.EPSG3857                                                       Projection used for this service.
-===============   ===================================================================================   ===
+.. autoclass:: ipyleaflet.leaflet.WMSLayer
+   :members:

--- a/docs/source/api_reference/zoom_control.rst
+++ b/docs/source/api_reference/zoom_control.rst
@@ -17,12 +17,5 @@ Example
 Attributes
 ----------
 
-================    ================   ===
-Attribute           Default Value      Doc
-================    ================   ===
-position            'topleft'          Position of the control, can be 'bottomleft', 'bottomright', 'topleft', or 'topright'
-zoom_in_text        '+'                Text to show in the "zoom in" button
-zoom_in_title       'Zoom in'          Text to show on mouse hover on the "zoom in" button
-zoom_out_text       '-'                Text to show in the "zoom out" button
-zoom_out_title      'Zoom out'         Text to show on mouse hover on the "zoom out" button
-================    ================   ===
+.. autoclass:: ipyleaflet.leaflet.ZoomControl
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,10 +2,11 @@
 import sphinx_rtd_theme
 
 extensions = [
-    'jupyter_sphinx',
+    'jupyter_sphinx', 'sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.napoleon','sphinx.ext.todo', 'sphinx.ext.viewcode'
 ]
 
 templates_path = ['_templates']
+
 
 
 def setup(app):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,6 +65,12 @@ ipyleaflet: Interactive maps in the Jupyter notebook
     api_reference/search_control
 
 .. toctree::
+    :caption: API Reference
+    :maxdepth: 2
+
+    api
+
+.. toctree::
     :caption: ipyleaflet related projects
     :maxdepth: 2
 

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -248,7 +248,7 @@ class Icon(UILayer):
 
     Attributes
     ----------
-    icon_url : string
+    icon_url : string, default ""
         The url to the image used for the icon.
     shadow_url: string, default None
         The url to the image used for the icon shadow.
@@ -400,6 +400,10 @@ class Marker(UILayer):
         The rotation angle of the marker in degrees.
     rotation_origin: string, default ''
         The rotation origin of the marker.
+    z_index_offset: int, default 0
+    opacity: float, default	1.0
+    rise_offset: int, default 250
+        The z-index offset used for the rise_on_hover feature
     """
 
     _view_name = Unicode('LeafletMarkerView').tag(sync=True)
@@ -464,6 +468,7 @@ class Popup(UILayer):
     auto_pan: boolean, default True
         Set it to False if you don’t want the map to do panning
         animation to fit the opened popup.
+    auto_pan_padding: tuple, default (5, 5)
     keep_in_view: boolean, default False
         Set it to True if you want to prevent users from panning
         the popup off of the screen while it is open.
@@ -547,20 +552,25 @@ class TileLayer(RasterLayer):
         Minimum zoom for this tile service.
     max_zoom: int, default 18
         Maximum zoom for this tile service.
+    min_native_zoom: int, default 0
+    max_native_zoom: int, default 18
     bounds: list or None, default None
         List of SW and NE location tuples. e.g. [(50, 75), (75, 120)].
-    tile_size int, default 256
+    tile_size: int, default 256
         Tile sizes for this tile service.
-    attribution string, default "Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors"
+    attribution: string, default "Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors"
         Tiles service attribution.
-    no_wrap boolean, default False
+    no_wrap: boolean, default False
         Whether the layer is wrapped around the antimeridian.
     tms: boolean, default False
         If true, inverses Y axis numbering for tiles (turn this on for TMS services).
     show_loading: boolean, default False
         Whether to show a spinner when tiles are loading.
-    loading: boolean, default False
+    loading: boolean, default False (dynamically updated)
         Whether the tiles are currently loading.
+    detect_retina: boolean, default	False
+    opacity: float, default 1.0
+    visible: boolean, default True
     """
 
     _view_name = Unicode('LeafletTileLayerView').tag(sync=True)
@@ -633,7 +643,7 @@ class LocalTileLayer(TileLayer):
 
 
 class WMSLayer(TileLayer):
-    """WMSLayer class.
+    """WMSLayer class, with TileLayer as a parent class.
 
     Attributes
     ----------
@@ -761,9 +771,10 @@ class VideoOverlay(RasterLayer):
 
 
 class Heatmap(RasterLayer):
-    """Heatmap class.
+    """Heatmap class, with RasterLayer as parent class.
 
     Heatmap layer.
+
 
     Attributes
     ----------
@@ -792,9 +803,10 @@ class Heatmap(RasterLayer):
 
 
 class VectorTileLayer(Layer):
-    """VectorTileLayer class.
+    """VectorTileLayer class, with Layer as parent class.
 
     Vector tile layer.
+
 
     Attributes
     ----------
@@ -876,7 +888,7 @@ class Path(VectorLayer):
 
 
 class AntPath(VectorLayer):
-    """AntPath class.
+    """AntPath class, with VectorLayer as parent class.
 
     AntPath layer.
 
@@ -903,6 +915,8 @@ class AntPath(VectorLayer):
         Whether the animation is going backwards or not.
     hardware_accelerated: boolean, default False
         Whether the ant-path uses hardware acceleration.
+    radius: int, default 10
+        Radius of the circle, if use is set to ‘circle’
     """
 
     _view_name = Unicode('LeafletAntPathView').tag(sync=True)
@@ -924,7 +938,7 @@ class AntPath(VectorLayer):
 
 
 class Polyline(Path):
-    """Polyline abstract class.
+    """Polyline abstract class, with Path as parent class.
 
     Attributes
     ----------
@@ -960,7 +974,7 @@ class Polyline(Path):
 
 
 class Polygon(Polyline):
-    """Polygon class.
+    """Polygon class, with Polyline as parent class.
 
     Polygon layer.
     """
@@ -970,7 +984,7 @@ class Polygon(Polyline):
 
 
 class Rectangle(Polygon):
-    """Rectangle class.
+    """Rectangle class, with Polygon as parent class.
 
     Rectangle layer.
 
@@ -987,7 +1001,7 @@ class Rectangle(Polygon):
 
 
 class CircleMarker(Path):
-    """CircleMarker class.
+    """CircleMarker class, with Path as parent class.
 
     CircleMarker layer.
 
@@ -1009,14 +1023,9 @@ class CircleMarker(Path):
 
 
 class Circle(CircleMarker):
-    """Circle class.
+    """Circle class, with CircleMarker as parent class.
 
     Circle layer.
-
-    Attributes
-    ----------
-    radius: int, default 1000
-        Radius of the circle marker in meters.
     """
 
     _view_name = Unicode('LeafletCircleView').tag(sync=True)
@@ -1027,7 +1036,7 @@ class Circle(CircleMarker):
 
 
 class MarkerCluster(Layer):
-    """MarkerCluster class.
+    """MarkerCluster class, with Layer as parent class.
 
     A cluster of markers that you can put on the map like other layers.
 
@@ -1051,7 +1060,7 @@ class LayerGroup(Layer):
 
     A group of layers that you can put on the map like other layers.
 
-    Attributes
+    Attributes and methods
     ----------
     layers: list, default []
         List of layers to include in the group.
@@ -1131,11 +1140,11 @@ class FeatureGroup(LayerGroup):
 
 
 class GeoJSON(FeatureGroup):
-    """GeoJSON class.
+    """GeoJSON class, with FeatureGroup as parent class.
 
     Layer created from a GeoJSON data structure.
 
-    Attributes
+    Attributes and methods
     ----------
     data: dict, default {}
         The JSON data structure.
@@ -1268,7 +1277,7 @@ class GeoJSON(FeatureGroup):
 
 
 class GeoData(GeoJSON):
-    """GeoData class.
+    """GeoData class with GeoJSON as parent class.
 
     Layer created from a GeoPandas dataframe.
 
@@ -1303,7 +1312,7 @@ class GeoData(GeoJSON):
 
 
 class Choropleth(GeoJSON):
-    """Choropleth class.
+    """Choropleth class, with GeoJSON as parent class.
 
     Layer showing a Choropleth effect on a GeoJSON structure.
 
@@ -1465,9 +1474,9 @@ class Control(Widget):
 
 
 class WidgetControl(Control):
-    """WidgetControl class.
+    """WidgetControl class, with Control as parent class.
 
-    A control that contain any DOMWidget instance.
+    A control that contains any DOMWidget instance.
 
     Attributes
     ----------
@@ -1490,7 +1499,7 @@ class WidgetControl(Control):
 
 
 class FullScreenControl(Control):
-    """FullScreenControl class.
+    """FullScreenControl class, with Control as parent class.
 
     A control which contains a button that will put the Map in
     full-screen when clicked.
@@ -1501,7 +1510,7 @@ class FullScreenControl(Control):
 
 
 class LayersControl(Control):
-    """LayersControl class.
+    """LayersControl class, with Control as parent class.
 
     A control which allows hiding/showing different layers on the Map.
     """
@@ -1511,11 +1520,11 @@ class LayersControl(Control):
 
 
 class MeasureControl(Control):
-    """MeasureControl class.
+    """MeasureControl class, with Control as parent class.
 
     A control which allows making measurements on the Map.
 
-    Attributes
+    Attributes and methods
     ----------
     primary_length_unit: str, default 'feet'
         Possible values are 'feet', 'meters', 'miles', 'kilometers' or any user
@@ -1625,7 +1634,7 @@ class MeasureControl(Control):
 
 
 class SplitMapControl(Control):
-    """SplitMapControl class.
+    """SplitMapControl class, with Control as parent class.
 
     A control which allows comparing layers by splitting the map in two.
 
@@ -1756,7 +1765,7 @@ class DrawControl(Control):
 
 
 class ZoomControl(Control):
-    """ZoomControl class.
+    """ZoomControl class, with Control as parent class.
 
     A control which contains buttons for zooming in/out the Map.
 
@@ -1784,7 +1793,7 @@ class ZoomControl(Control):
 
 
 class ScaleControl(Control):
-    """ScaleControl class.
+    """ScaleControl class, with Control as parent class.
 
     A control which shows the Map scale.
 
@@ -1820,7 +1829,7 @@ class AttributionControl(Control):
 
 
 class LegendControl(Control):
-    """LegendControl class.
+    """LegendControl class, with Control as parent class.
 
     A control which contains a legend.
 
@@ -1904,7 +1913,22 @@ class LegendControl(Control):
 
 
 class SearchControl(Control):
-    """ SearchControl Widget """
+    """ SearchControl class, with Control as parent class.
+
+    Attributes and methods
+    ----------
+
+    url: string, default ""
+        The url used for the search queries.
+    layer:	default None
+        The LayerGroup used for search queries.
+    zoom: int, default None
+        The zoom level after moving to searched location, by default zoom level will not change.
+    marker:	default Marker()
+        The marker used by the control.
+    found_style: default {‘fillColor’: ‘#3f0’, ‘color’: ‘#0f0’}
+        Style for searched feature when searching in LayerGroup.
+    """
     _view_name = Unicode('LeafletSearchControlView').tag(sync=True)
     _model_name = Unicode('LeafletSearchControlModel').tag(sync=True)
 
@@ -1991,14 +2015,51 @@ class Map(DOMWidget, InteractMixin):
         The current center of the map.
     zoom: float, default 12
         The current zoom value of the map.
+    max_zoom: int, default 18
+        Maximal zoom value.
+    min_zoom: int, default 1
+        Minimal zoom value.
     zoom_snap: float, default 1
-        Forces the map’s zoom level to always be a multiple of this..
+        Forces the map’s zoom level to always be a multiple of this.
     zoom_delta: float, default 1
         Controls how much the map’s zoom level will change after
         pressing + or - on the keyboard, or using the zoom controls.
     crs: projection, default projections.EPSG3857
         Coordinate reference system, which can be ‘Earth’, ‘EPSG3395’, ‘EPSG3857’,
         ‘EPSG4326’, ‘Base’, ‘Simple’ or user defined projection.
+    dragging: boolean, default True
+        Whether the map be draggable with mouse/touch or not.
+    touch_zoom: boolean, default True
+        Whether the map can be zoomed by touch-dragging with two fingers on mobile.
+    scroll_wheel_zoom: boolean,default False
+        Whether the map can be zoomed by using the mouse wheel.
+    double_click_zoom: boolean,	default True
+        Whether the map can be zoomed in by double clicking on it and zoomed out by double clicking while holding shift.
+    box_zoom: boolean, default True
+        Whether the map can be zoomed to a rectangular area specified by dragging the mouse while pressing the shift key
+    tap: boolean, default True
+        Enables mobile hacks for supporting instant taps.
+    tap_tolerance: int, default	15
+        The max number of pixels a user can shift his finger during touch for it to be considered a valid tap.
+    world_copy_jump: boolean, default False
+        With this option enabled, the map tracks when you pan to another “copy” of the world and seamlessly jumps to.
+    close_popup_on_click: boolean, default True
+        Set it to False if you don’t want popups to close when user clicks the map.
+    bounce_at_zoom_limits: boolean,	default True
+        Set it to False if you don’t want the map to zoom beyond min/max zoom and then bounce back when pinch-zooming.
+    keyboard: booelan, default True
+        Makes the map focusable and allows users to navigate the map with keyboard arrows and +/- keys.
+    keyboard_pan_offset: int, default 80
+    keyboard_zoom_offset: int, default 1
+    inertia: boolean, default True
+        If enabled, panning of the map will have an inertia effect.
+    inertia_deceleration: float, default 3000
+        The rate with which the inertial movement slows down, in pixels/second².
+    inertia_max_speed: float, default 1500
+        Max speed of the inertial movement, in pixels/second.
+    zoom_control: boolean, default True
+    attribution_control: boolean, default True
+    zoom_animation_threshold: int, default 4
     """
 
     _view_name = Unicode('LeafletMapView').tag(sync=True)

--- a/ipyleaflet/velocity.py
+++ b/ipyleaflet/velocity.py
@@ -10,6 +10,38 @@ from .xarray_ds import ds_x_to_json
 
 
 class Velocity(Layer):
+    """Velocity class, with Layer as parent class
+
+    To visualize the direction and intensity of arbitrary velocities
+
+    Attributes
+    ----------
+    data: dataset, default Empty dataset
+        Underlying dataset
+    zonal_speed: string, default ''
+        Variable name in underlying dataset for the zonal speed.
+    meridional_speed: string, default ''
+       Variable name in underlying dataset for the meridional speed.
+    latitude_dimension: string, default Empty dataset.
+        Name of the latitude dimension in underlying dataset.
+    longitude_dimension: string, default True
+        Name of the longitude dimension in underlying dataset.
+    units: string, default None
+        Whether to show imperial units.
+    display_values: bool, default True
+        Display velocity data on mouse hover.
+    display_options: dict, default {}
+        Display options.
+    min_velocity: float, default 0
+        Used to align color scale
+    max_velocity: float, default 10.0
+        Used to align color scale.
+    velocity_scale: float, 0.005
+        To be modified for particle animations.
+    color_scale: array, default []
+        Array of hex/rgb colors for user-specified color scale.
+    """
+
     _view_name = Unicode('LeafletVelocityView').tag(sync=True)
     _model_name = Unicode('LeafletVelocityModel').tag(sync=True)
 


### PR DESCRIPTION
use autodoc to replace the attributes and methods tables of the documentation by the autogeneration using docstrings
write the docstrings of velocity.Velocity class
add a page named API reference page for the leaflet module
add changes to homogenize the structure/names of the sections of the different pages

Fix #915