### PR TITLE
Fix formatting issues in the doc for attributes and methods sections using autodoc

### DIFF
--- a/docs/source/controls/draw_control.rst
+++ b/docs/source/controls/draw_control.rst
@@ -52,8 +52,8 @@ Example
 
     m
 
-Attributes
-----------
+Methods
+-------
 
 .. autoclass:: ipyleaflet.leaflet.DrawControl
    :members:

--- a/docs/source/controls/legend_control.rst
+++ b/docs/source/controls/legend_control.rst
@@ -34,8 +34,8 @@ Example
     legend.position = "topright"  # Set position
     legend.position  # Get current position
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
 .. autoclass:: ipyleaflet.leaflet.LegendControl
    :members:

--- a/docs/source/controls/measure_control.rst
+++ b/docs/source/controls/measure_control.rst
@@ -28,8 +28,8 @@ Example
     m
 
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
 .. autoclass:: ipyleaflet.leaflet.MeasureControl
    :members:

--- a/docs/source/controls/search_control.rst
+++ b/docs/source/controls/search_control.rst
@@ -78,7 +78,7 @@ You can also search features from GeoJSON layers.
 
     m
 
-Methods
+Attributes and methods
 -------
 
 .. autoclass:: ipyleaflet.leaflet.SearchControl

--- a/docs/source/layers/layer_group.rst
+++ b/docs/source/layers/layer_group.rst
@@ -32,8 +32,8 @@ Example
     m
 
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
 .. autoclass:: ipyleaflet.leaflet.LayerGroup
    :members:

--- a/docs/source/layers/popup.rst
+++ b/docs/source/layers/popup.rst
@@ -40,8 +40,8 @@ Example
     m
 
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
 .. autoclass:: ipyleaflet.leaflet.Popup
    :members:

--- a/docs/source/layers/vector_tile.rst
+++ b/docs/source/layers/vector_tile.rst
@@ -138,8 +138,8 @@ Example
     m
 
 
-Attributes
-----------
+Attributes and methods
+----------------------
 
 .. autoclass:: ipyleaflet.leaflet.VectorTileLayer
    :members:

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1060,7 +1060,7 @@ class LayerGroup(Layer):
 
     A group of layers that you can put on the map like other layers.
 
-    Attributes and methods
+    Attributes
     ----------
     layers: list, default []
         List of layers to include in the group.
@@ -1144,7 +1144,7 @@ class GeoJSON(FeatureGroup):
 
     Layer created from a GeoJSON data structure.
 
-    Attributes and methods
+    Attributes
     ----------
     data: dict, default {}
         The JSON data structure.
@@ -1524,20 +1524,16 @@ class MeasureControl(Control):
 
     A control which allows making measurements on the Map.
 
-    Attributes and methods
-    ----------
+    Attributes
+    ----------------------
     primary_length_unit: str, default 'feet'
-        Possible values are 'feet', 'meters', 'miles', 'kilometers' or any user
-        defined unit.
+        Possible values are 'feet', 'meters', 'miles', 'kilometers' or any user defined unit.
     secondary_length_unit: str, default None
-        Possible values are 'feet', 'meters', 'miles', 'kilometers' or any user
-        defined unit.
+        Possible values are 'feet', 'meters', 'miles', 'kilometers' or any user defined unit.
     primary_area_unit: str, default 'acres'
-        Possible values are 'acres', 'hectares', 'sqfeet', 'sqmeters', 'sqmiles'
-        or any user defined unit.
+        Possible values are 'acres', 'hectares', 'sqfeet', 'sqmeters', 'sqmiles' or any user defined unit.
     secondary_area_unit: str, default None
-        Possible values are 'acres', 'hectares', 'sqfeet', 'sqmeters', 'sqmiles'
-        or any user defined unit.
+        Possible values are 'acres', 'hectares', 'sqfeet', 'sqmeters', 'sqmiles' or any user defined unit.
     active_color: CSS Color, default '#ABE67E'
         The color used for current measurements.
     completed_color: CSS Color, default '#C8F2BE'
@@ -1915,7 +1911,7 @@ class LegendControl(Control):
 class SearchControl(Control):
     """ SearchControl class, with Control as parent class.
 
-    Attributes and methods
+    Attributes
     ----------
 
     url: string, default ""


### PR DESCRIPTION
In the documentation, fix some formatting issues in the attributes/attributes and methods/methods sections using autodoc.