### PR TITLE
Docs remove hydda

### DIFF
--- a/docs/source/controls/measure_control.rst
+++ b/docs/source/controls/measure_control.rst
@@ -8,7 +8,7 @@ Example
 
     from ipyleaflet import Map, MeasureControl, basemaps
 
-    m = Map(center=(43.0327, 6.0232), zoom=9, basemap=basemaps.Hydda.Full)
+    m = Map(center=(43.0327, 6.0232), zoom=9, basemap=basemaps.OpenStreetMap.Mapnik)
 
     measure = MeasureControl(
         position='bottomleft',

--- a/docs/source/layers/tile_layer.rst
+++ b/docs/source/layers/tile_layer.rst
@@ -33,7 +33,7 @@ Sometimes one could want to specify the date of the given images, for instance w
 
 Attributes and methods
 ----------------------
-
+Note that if you want to display a high resolution layer with a quite large zoom, you have to set ``max_zoom`` and ``max_native_zoom`` with equal value.
 .. autoclass:: ipyleaflet.leaflet.TileLayer
    :members:
 

--- a/examples/BaseMap.ipynb
+++ b/examples/BaseMap.ipynb
@@ -15,6 +15,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "m = Map(center=(52, 10), zoom=8, basemap=basemaps.OpenStreetMap.Mapnik)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "strava_all = basemap_to_tiles(basemaps.Strava.All)\n",
     "m.add_layer(strava_all)"
    ]

--- a/examples/BaseMap.ipynb
+++ b/examples/BaseMap.ipynb
@@ -15,16 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(center=(52, 10), zoom=8, basemap=basemaps.Hydda.Full)\n",
-    "m"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "strava_all = basemap_to_tiles(basemaps.Strava.All)\n",
     "m.add_layer(strava_all)"
    ]

--- a/examples/LayerGroup.ipynb
+++ b/examples/LayerGroup.ipynb
@@ -15,16 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(center=(52, 10), zoom=8, basemap=basemaps.Hydda.Full)\n",
-    "m"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Create a few layers\n",
     "marker = Marker(location=(52, 10))\n",
     "circle = Circle(location=(52, 12), radius=50000)\n",

--- a/examples/LayerGroup.ipynb
+++ b/examples/LayerGroup.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d09636fdd9844f5be84eac15f72456d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[52, 10], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out_tex…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "m = Map(center=(52, 10), zoom=8, basemap=basemaps.OpenStreetMap.Mapnik)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +91,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -80,9 +105,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/MeasureControl.ipynb
+++ b/examples/MeasureControl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,11 +11,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ade868b12827419cbca15d69f1d557fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[43.0327, 6.0232], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoo…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "m = Map(center=(43.0327, 6.0232), zoom=9, basemap=basemaps.Hydda.Full)\n",
+    "m = Map(center=(43.0327, 6.0232), zoom=9, basemap=basemaps.OpenStreetMap.Mapnik)\n",
     "m"
    ]
   },
@@ -63,7 +78,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -77,9 +92,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In the documentation and in the examples' notebooks, replace any reference to Hydda by another basemap.