### PR TITLE
Update try it online in the documentation.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ ipyleaflet: Interactive maps in the Jupyter notebook
 Try it online
 -------------
 
-Directly from this page, you can make a try with ipyleaflet with clicking on `Try it on RetroLab <https://ipyleaflet.readthedocs.io/en/latest/lite/retro>`__ or
+You can give ipyleaflet a try in this documentation by clicking on `Try it on RetroLab <https://ipyleaflet.readthedocs.io/en/latest/lite/retro>`__ or
 `Try it on JupyterLab <https://ipyleaflet.readthedocs.io/en/latest/lite/lab>`__.
 
 Index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,9 +5,8 @@ ipyleaflet: Interactive maps in the Jupyter notebook
 Try it online
 -------------
 
-You can try ipyleaflet directly in this documentation page thanks to JupyterLite!
-
-.. retrolite:: ipyleaflet.ipynb
+Directly from this page, you can make a try with ipyleaflet with clicking on `Try it on RetroLab <https://ipyleaflet.readthedocs.io/en/latest/lite/retro>`__ or
+`Try it on JupyterLab <https://ipyleaflet.readthedocs.io/en/latest/lite/lab>`__.
 
 Index
 -----

--- a/docs/source/ipyleaflet.ipynb
+++ b/docs/source/ipyleaflet.ipynb
@@ -3,18 +3,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8eee1995-a52b-4eae-8898-047746e57b19",
+   "id": "1d3b8b34",
    "metadata": {},
    "outputs": [],
    "source": [
     "import piplite\n",
-    "await piplite.install('ipyleaflet')"
+    "await piplite.install('ipyleaflet');"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbabb8a7",
+   "id": "48a5cc23",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
In the documentation, in index.rst, change the try it online : replace the retrolite directive by 2 links to retro and lab.