### PR TITLE
Support both processPhosphorMessage and processLuminoMessage

### DIFF
--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -408,8 +408,16 @@ export class LeafletMapView extends utils.LeafletDOMWidgetView {
     }
   }
 
+  processPhosphorMessage(msg) {
+    this._processLuminoMessage(msg, super.processPhosphorMessage);
+  }
+
   processLuminoMessage(msg) {
-    super.processLuminoMessage(msg);
+    this._processLuminoMessage(msg, super.processLuminoMessage);
+  }
+
+  _processLuminoMessage(msg, _super) {
+    _super.call(this, msg);
     switch (msg.type) {
       case 'resize':
         // We set the dirty flag to true to prevent the sub-pixel error


### PR DESCRIPTION
This ensures compatibility with ipywidgets 7 and 8.

In https://github.com/jupyter-widgets/ipyleaflet/pull/771, `processPhosphorMessage` was renamed to `processLuminoMessage`, but that renaming should be done at the ipywidgets 7/8 transition, as ipywidgets 7 does not support `processLuminoMessage`.

This PR implements @vidartf's compatibility shim for ipywidgets 7 and 8 that he posted in https://github.com/jupyter-widgets/ipywidgets/pull/3405#pullrequestreview-907246241

Fixes #773

Before this PR, notice the resize does not work in ipywidgets 7.7:

![mapbefore](https://user-images.githubusercontent.com/192614/163679335-9b3637ca-e39f-4f89-8451-642cf228eda8.gif)

But after this PR, the resize does work in ipywidgets 7.7 (and should still work in ipywidgets 8):

![mapafter](https://user-images.githubusercontent.com/192614/163679362-61571722-4b31-4001-a66a-ce8b4575e048.gif)
