### PR TITLE
Document use of multiple basemaps

### DIFF
--- a/docs/source/layers/tile_layer.rst
+++ b/docs/source/layers/tile_layer.rst
@@ -31,9 +31,32 @@ Sometimes one could want to specify the date of the given images, for instance w
     nasa_layer = basemap_to_tiles(basemaps.NASAGIBS.ModisTerraTrueColorCR, "2018-04-08");
     m.add_layer(nasa_layer);
 
+.. _Tile Layer Basemap:
+
+To use multiple base maps and the built in base map switching in ``LayerControl``, it is possible to create the desired  ``TileLayer`` objects and set ``base`` to ``True``.
+These layers can then be passed in an array to ``Map(layers)``:
+
+.. jupyter-execute::
+    
+    from ipyleaflet import Map, basemaps, basemap_to_tiles
+    from ipyleaflet import LayersControl
+    
+    mapnik = basemap_to_tiles(basemaps.OpenStreetMap.Mapnik)
+    mapnik.base = True
+    toner = basemap_to_tiles(basemaps.Stamen.Toner)
+    toner.base = True
+
+    m = Map(layers=[mapnik, toner], center=(52.204793, 360.121558), zoom=9)
+    
+    # use the LayersControl to switch basemaps
+    m.add_control(LayersControl())
+    m
+
 Attributes and methods
 ----------------------
+
 Note that if you want to display a high resolution layer with a quite large zoom, you have to set ``max_zoom`` and ``max_native_zoom`` with equal value.
+
 .. autoclass:: ipyleaflet.leaflet.TileLayer
    :members:
 

--- a/docs/source/map_and_basemaps/map.rst
+++ b/docs/source/map_and_basemaps/map.rst
@@ -54,6 +54,8 @@ As a Jupyter interactive widget, the layout of the ``Map`` object is specified b
 
     m
 
+You can use multiple basemaps my manually creating ``TileLayer`` objects and passing them to the ``Map`` constructor. (see :ref:`TileLayer Usage<Tile Layer Basemap>`)
+
 Save to HTML
 ------------
 


### PR DESCRIPTION
Per the information in https://github.com/jupyter-widgets/ipyleaflet/issues/970 which I have tested and can confirm works, this PR updates the documentation to include an example of using multiple base layers on the TileLayer page, as well as a one sentence reference to it on the Map page.

- [x]  Tested my changes to ensure they built properly in sphinx.

Thank you!