### PR TITLE
Rerender map when changing Map.dragging

### DIFF
--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -345,6 +345,19 @@ export class LeafletMapView extends utils.LeafletDOMWidgetView {
     );
     this.listenTo(
       this.model,
+      'change:dragging',
+      function () {
+        if (this.model.get('dragging')) {
+          this.obj.dragging.enable();
+        }
+        else {
+          this.obj.dragging.disable();
+        }
+      },
+      this
+    );
+    this.listenTo(
+      this.model,
       'change:layers',
       function () {
         this.layer_views.update(this.model.get('layers'));


### PR DESCRIPTION
Fixes #977

It works, but when `dragging` is set the second time, we get this error in the console:
```
272.eb0d340….js:1 Error setting state: Cannot convert undefined or null to object
t.set_state	@	272.eb0d340….js:1
(anonymous)	@	272.eb0d340….js:1
Promise.then (async)		
t._handle_comm_msg	@	272.eb0d340….js:1
_handleCommMsg	@	jlab_core.fc632a0f38…32a0f38747f007842:2
_handleMessage	@	jlab_core.fc632a0f38…32a0f38747f007842:2
await in _handleMessage (async)		
(anonymous)	@	jlab_core.fc632a0f38…32a0f38747f007842:2
Promise.then (async)		
_onWSMessage	@	jlab_core.fc632a0f38…32a0f38747f007842:2
```
Looks like a low-level widget comm message error. Any idea @martinRenou ?