### PR TITLE
Update JupyterLite to include lots of examples

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,5 +18,7 @@ dependencies:
 
   - pip:
     - ..
-    - jupyterlite-sphinx
+    # Until jupyterlite-sphinx>0.4.9 is released, install from a commit hash to get the jupyterlite_contents config option
+    # - jupyterlite-sphinx
+    - https://github.com/jupyterlite/jupyterlite-sphinx/archive/944ccf4ee977627dbf75b5ae1994c08718566c76.zip
     - jupyterlite>=0.1.0b9

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,59 +8,59 @@ templates_path = ['_templates']
 
 jupyterlite_config = "jupyterlite_config.json"
 jupyterlite_contents = [
-    "../examples/europe_110.geo.json",
-    "../examples/bars.json",
-    "../examples/demo.json",
-    "../examples/US_Unemployment_Oct2012.csv",
-    "../examples/US_Unemployment_Oct2012_with_NANS.csv",
-    "../examples/us-states.json",
-    "../examples/AntPath.ipynb",
-    "../examples/AwesomeIcons.ipynb",
-    "../examples/BaseMap.ipynb",
-#    "../examples/CanvasRenderer.ipynb", # no python wheel for shapely
-    "../examples/Choropleth.ipynb",
-    "../examples/Choropleth_with_NANS.ipynb",
-#    "../examples/CountriesGeoJSON.ipynb", # cannot access ./europe_110.geo.json
-    "../examples/CustomProjections.ipynb",
-    "../examples/CustomTMS.ipynb",
-#    "../examples/CustomTileServer.ipynb", # Some problem with flask: 'DummyMod' object has no attribute 'startswith'
-    "../examples/DrawControl.ipynb",
-    "../examples/DropdownControl.ipynb",
-    "../examples/Fullscreen.ipynb",
-#     "../examples/GPX.ipynb", # error installing geopandas (missing wheel for pyproj)
-#     "../examples/GeoData.ipynb", # error installing geopandas (missing wheel for pyproj)
-#     "../examples/GeoData_on_hover.ipynb",  # error installing geopandas (missing wheel for pyproj)
-    "../examples/GeoJSON.ipynb",
-#     "../examples/GeoJson_EU_on_hover.ipynb", # cannot load file europe_110.geo.json
-    "../examples/Heatmap.ipynb",
-#     "../examples/Image_slider.ipynb", # error installing rasterio
-#     "../examples/KML.ipynb", # error installing geopandas
-    "../examples/LayerGroup.ipynb",
-    "../examples/LegendControl.ipynb",
-    "../examples/MagnifyingGlass.ipynb",
-    "../examples/MapContainer.ipynb",
-    "../examples/MapCursorStyle.ipynb",
-    "../examples/MapPanes.ipynb", # This works even though it also needs the europe_110.geo.json, so check example above again!
-#     "../examples/MarkerCluster-GeoJson.ipynb", # error installing geopandas
-#    "../examples/MarkerCluster.ipynb", #error install geopandas
-#    "../examples/Max_zoom.ipynb", # test again - not sure if localtileserver package has problems
-    "../examples/MeasureControl.ipynb",
-#     "../examples/Numpy.ipynb", # error installing reasterio
-    "../examples/Primitives.ipynb",
-    "../examples/Radiation.ipynb",
-    "../examples/ScaleControl.ipynb",
-#     "../examples/SearchControl.ipynb", # error installing shapely. Looks like reading a file works if it is readonly (opened with "r")
-    "../examples/Select-GeoJson.ipynb",
-    "../examples/SplitMap.ipynb",
-    "../examples/TileLayer-loading.ipynb",
-    "../examples/Transform.ipynb",
-    "../examples/VectorTiles.ipynb",
-#    "../examples/Velocity.ipynb", # seems like issues with downloading wind-global.nc dataset? Takes a long time
-#    "../examples/Video.ipynb", # error installing rasterio
-#     "../examples/WKTLayer.ipynb", #error importing shapely
-    "../examples/WMSLayer.ipynb",
-#    "../examples/WealthOfNations.ipynb", # did not install bqplot widget as a federated extension?
-    "../examples/WidgetControl.ipynb",
+    "../../examples/europe_110.geo.json",
+    "../../examples/bars.json",
+    "../../examples/demo.json",
+    "../../examples/US_Unemployment_Oct2012.csv",
+    "../../examples/US_Unemployment_Oct2012_with_NANS.csv",
+    "../../examples/us-states.json",
+    "../../examples/AntPath.ipynb",
+    "../../examples/AwesomeIcons.ipynb",
+    "../../examples/BaseMap.ipynb",
+#    "../../examples/CanvasRenderer.ipynb", # no python wheel for shapely
+    "../../examples/Choropleth.ipynb",
+    "../../examples/Choropleth_with_NANS.ipynb",
+#    "../../examples/CountriesGeoJSON.ipynb", # cannot access ./europe_110.geo.json
+    "../../examples/CustomProjections.ipynb",
+    "../../examples/CustomTMS.ipynb",
+#    "../../examples/CustomTileServer.ipynb", # Some problem with flask: 'DummyMod' object has no attribute 'startswith'
+    "../../examples/DrawControl.ipynb",
+    "../../examples/DropdownControl.ipynb",
+    "../../examples/Fullscreen.ipynb",
+#     "../../examples/GPX.ipynb", # error installing geopandas (missing wheel for pyproj)
+#     "../../examples/GeoData.ipynb", # error installing geopandas (missing wheel for pyproj)
+#     "../../examples/GeoData_on_hover.ipynb",  # error installing geopandas (missing wheel for pyproj)
+    "../../examples/GeoJSON.ipynb",
+#     "../../examples/GeoJson_EU_on_hover.ipynb", # cannot load file europe_110.geo.json
+    "../../examples/Heatmap.ipynb",
+#     "../../examples/Image_slider.ipynb", # error installing rasterio
+#     "../../examples/KML.ipynb", # error installing geopandas
+    "../../examples/LayerGroup.ipynb",
+    "../../examples/LegendControl.ipynb",
+    "../../examples/MagnifyingGlass.ipynb",
+    "../../examples/MapContainer.ipynb",
+    "../../examples/MapCursorStyle.ipynb",
+    "../../examples/MapPanes.ipynb", # This works even though it also needs the europe_110.geo.json, so check example above again!
+#     "../../examples/MarkerCluster-GeoJson.ipynb", # error installing geopandas
+#    "../../examples/MarkerCluster.ipynb", #error install geopandas
+#    "../../examples/Max_zoom.ipynb", # test again - not sure if localtileserver package has problems
+    "../../examples/MeasureControl.ipynb",
+#     "../../examples/Numpy.ipynb", # error installing reasterio
+    "../../examples/Primitives.ipynb",
+    "../../examples/Radiation.ipynb",
+    "../../examples/ScaleControl.ipynb",
+#     "../../examples/SearchControl.ipynb", # error installing shapely. Looks like reading a file works if it is readonly (opened with "r")
+    "../../examples/Select-GeoJson.ipynb",
+    "../../examples/SplitMap.ipynb",
+    "../../examples/TileLayer-loading.ipynb",
+    "../../examples/Transform.ipynb",
+    "../../examples/VectorTiles.ipynb",
+#    "../../examples/Velocity.ipynb", # seems like issues with downloading wind-global.nc dataset? Takes a long time
+#    "../../examples/Video.ipynb", # error installing rasterio
+#     "../../examples/WKTLayer.ipynb", #error importing shapely
+    "../../examples/WMSLayer.ipynb",
+#    "../../examples/WealthOfNations.ipynb", # did not install bqplot widget as a federated extension?
+    "../../examples/WidgetControl.ipynb",
 ]
 def setup(app):
     app.add_css_file("main_stylesheet.css")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,61 @@ extensions = [
 templates_path = ['_templates']
 
 jupyterlite_config = "jupyterlite_config.json"
-jupyterlite_contents = "../examples"
-
+jupyterlite_contents = [
+    "../examples/europe_110.geo.json",
+    "../examples/bars.json",
+    "../examples/demo.json",
+    "../examples/US_Unemployment_Oct2012.csv",
+    "../examples/US_Unemployment_Oct2012_with_NANS.csv",
+    "../examples/us-states.json",
+    "../examples/AntPath.ipynb",
+    "../examples/AwesomeIcons.ipynb",
+    "../examples/BaseMap.ipynb",
+#    "../examples/CanvasRenderer.ipynb", # no python wheel for shapely
+    "../examples/Choropleth.ipynb",
+    "../examples/Choropleth_with_NANS.ipynb",
+#    "../examples/CountriesGeoJSON.ipynb", # cannot access ./europe_110.geo.json
+    "../examples/CustomProjections.ipynb",
+    "../examples/CustomTMS.ipynb",
+#    "../examples/CustomTileServer.ipynb", # Some problem with flask: 'DummyMod' object has no attribute 'startswith'
+    "../examples/DrawControl.ipynb",
+    "../examples/DropdownControl.ipynb",
+    "../examples/Fullscreen.ipynb",
+#     "../examples/GPX.ipynb", # error installing geopandas (missing wheel for pyproj)
+#     "../examples/GeoData.ipynb", # error installing geopandas (missing wheel for pyproj)
+#     "../examples/GeoData_on_hover.ipynb",  # error installing geopandas (missing wheel for pyproj)
+    "../examples/GeoJSON.ipynb",
+#     "../examples/GeoJson_EU_on_hover.ipynb", # cannot load file europe_110.geo.json
+    "../examples/Heatmap.ipynb",
+#     "../examples/Image_slider.ipynb", # error installing rasterio
+#     "../examples/KML.ipynb", # error installing geopandas
+    "../examples/LayerGroup.ipynb",
+    "../examples/LegendControl.ipynb",
+    "../examples/MagnifyingGlass.ipynb",
+    "../examples/MapContainer.ipynb",
+    "../examples/MapCursorStyle.ipynb",
+    "../examples/MapPanes.ipynb", # This works even though it also needs the europe_110.geo.json, so check example above again!
+#     "../examples/MarkerCluster-GeoJson.ipynb", # error installing geopandas
+#    "../examples/MarkerCluster.ipynb", #error install geopandas
+#    "../examples/Max_zoom.ipynb", # test again - not sure if localtileserver package has problems
+    "../examples/MeasureControl.ipynb",
+#     "../examples/Numpy.ipynb", # error installing reasterio
+    "../examples/Primitives.ipynb",
+    "../examples/Radiation.ipynb",
+    "../examples/ScaleControl.ipynb",
+#     "../examples/SearchControl.ipynb", # error installing shapely. Looks like reading a file works if it is readonly (opened with "r")
+    "../examples/Select-GeoJson.ipynb",
+    "../examples/SplitMap.ipynb",
+    "../examples/TileLayer-loading.ipynb",
+    "../examples/Transform.ipynb",
+    "../examples/VectorTiles.ipynb",
+#    "../examples/Velocity.ipynb", # seems like issues with downloading wind-global.nc dataset? Takes a long time
+#    "../examples/Video.ipynb", # error installing rasterio
+#     "../examples/WKTLayer.ipynb", #error importing shapely
+    "../examples/WMSLayer.ipynb",
+#    "../examples/WealthOfNations.ipynb", # did not install bqplot widget as a federated extension?
+    "../examples/WidgetControl.ipynb",
+]
 def setup(app):
     app.add_css_file("main_stylesheet.css")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,6 +7,7 @@ extensions = [
 templates_path = ['_templates']
 
 jupyterlite_config = "jupyterlite_config.json"
+jupyterlite_contents = "../examples"
 
 def setup(app):
     app.add_css_file("main_stylesheet.css")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,9 +12,11 @@ Python or from the browser.
 Try it online
 -------------
 
-You can try ipyleaflet below, or open the example in a new browser tab with
-`RetroLite <./lite/retro/notebooks?path=ipyleaflet.ipynb>`_ or
-`JupyterLite <./lite/lab?path=ipyleaflet.ipynb>`_.
+.. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
+   :target: ./lite/lab?path=ipyleaflet.ipynb
+
+You can try ipyleaflet below, or open many other live examples in a new browser tab with
+`JupyterLite <./lite/lab?path=ipyleaflet.ipynb>`_ or `RetroLite <./lite/retro/tree>`_.
 
 .. retrolite:: ipyleaflet.ipynb
 

--- a/examples/AntPath.ipynb
+++ b/examples/AntPath.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, AntPath"
    ]
   },
@@ -117,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -131,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/AwesomeIcons.ipynb
+++ b/examples/AwesomeIcons.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass# Set up for JupyterLite"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import json\n",
     "\n",
     "from ipyleaflet import AwesomeIcon, Marker, Map"
@@ -72,7 +86,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -86,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/BaseMap.ipynb
+++ b/examples/BaseMap.ipynb
@@ -2,6 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -151,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/CanvasRenderer.ipynb
+++ b/examples/CanvasRenderer.ipynb
@@ -3,6 +3,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "64f20cfc-a3c8-437a-8c64-a0264afdde0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "24ede0d7-88e1-4955-9094-e10a9aebe5e7",
    "metadata": {},
    "outputs": [],
@@ -70,7 +85,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Choropleth.ipynb
+++ b/examples/Choropleth.ipynb
@@ -2,6 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install(['ipyleaflet', 'branca'])\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -191,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Choropleth_with_NANS.ipynb
+++ b/examples/Choropleth_with_NANS.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install(['ipyleaflet', 'branca'])\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ipyleaflet\n",
     "from ipyleaflet import Map, LegendControl\n",
     "import json\n",
@@ -90,7 +104,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/CustomProjections.ipynb
+++ b/examples/CustomProjections.ipynb
@@ -16,6 +16,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    basemaps,\n",
@@ -100,7 +114,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -114,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/CustomTMS.ipynb
+++ b/examples/CustomTMS.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    Marker,\n",
@@ -65,7 +79,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -79,9 +93,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/DrawControl.ipynb
+++ b/examples/DrawControl.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    Marker,\n",
@@ -251,7 +265,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -265,9 +279,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/DropdownControl.ipynb
+++ b/examples/DropdownControl.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import basemaps, basemap_to_tiles, Map, WidgetControl\n",
     "from ipywidgets import Dropdown"
    ]
@@ -59,7 +73,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -73,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Fullscreen.ipynb
+++ b/examples/Fullscreen.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, FullScreenControl"
    ]
   },
@@ -24,7 +38,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -38,9 +52,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/GeoJSON.ipynb
+++ b/examples/GeoJSON.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    Marker,\n",
@@ -173,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Heatmap.ipynb
+++ b/examples/Heatmap.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, Heatmap\n",
     "from random import uniform\n",
     "import time"
@@ -105,7 +119,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -119,9 +133,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/LayerGroup.ipynb
+++ b/examples/LayerGroup.ipynb
@@ -2,6 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -127,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/LegendControl.ipynb
+++ b/examples/LegendControl.ipynb
@@ -1,12 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Legend Control"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Legend: How to use"
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
    ]
   },
   {
@@ -165,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/MagnifyingGlass.ipynb
+++ b/examples/MagnifyingGlass.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, MagnifyingGlass, basemaps, basemap_to_tiles"
    ]
   },
@@ -47,7 +61,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/MapContainer.ipynb
+++ b/examples/MapContainer.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    Marker,\n",
@@ -51,7 +65,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -65,9 +79,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/MapCursorStyle.ipynb
+++ b/examples/MapCursorStyle.ipynb
@@ -13,6 +13,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map\n",
     "\n",
     "m = Map()\n",
@@ -94,7 +108,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -108,9 +122,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/MapPanes.ipynb
+++ b/examples/MapPanes.ipynb
@@ -3,6 +3,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e5d59b9c-847f-49dc-9d8e-6ffb683fc214",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install(['ipyleaflet', 'requests'])\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "cbcccab4-2d48-4ed2-9a01-3aebef7a3f2e",
    "metadata": {},
    "outputs": [],

--- a/examples/MeasureControl.ipynb
+++ b/examples/MeasureControl.ipynb
@@ -2,6 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -92,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Primitives.ipynb
+++ b/examples/Primitives.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import (\n",
     "    Map,\n",
     "    Marker,\n",
@@ -562,7 +576,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -576,9 +590,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/Radiation.ipynb
+++ b/examples/Radiation.ipynb
@@ -3,6 +3,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "259d51a9-7483-4944-9f19-81d07febc425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install(['ipyleaflet', 'requests', 'ipyflex'])\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "43ef0082-9552-44e9-82d3-c1e27209d2c5",
    "metadata": {
     "lines_to_next_cell": 2,
@@ -190,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/ScaleControl.ipynb
+++ b/examples/ScaleControl.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, ScaleControl"
    ]
   },
@@ -34,7 +48,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -48,7 +62,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/SearchControl.ipynb
+++ b/examples/SearchControl.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "import json\n",
     "\n",
@@ -62,7 +76,7 @@
    "source": [
     "# Search in a GeoJSON layer\n",
     "\n",
-    "with open(\"countries.geo.json\") as f:\n",
+    "with open(\"countries.geo.json\", \"r\") as f:\n",
     "    data = json.load(f)\n",
     "\n",
     "countries = GeoJSON(data=data)\n",
@@ -152,7 +166,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -166,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Select-GeoJson.ipynb
+++ b/examples/Select-GeoJson.ipynb
@@ -3,6 +3,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -48,7 +62,7 @@
    "outputs": [],
    "source": [
     "# geojson layer with hover handler\n",
-    "with open(\"./europe_110.geo.json\") as f:\n",
+    "with open(\"./europe_110.geo.json\", \"r\") as f:\n",
     "    data = json.load(f)\n",
     "\n",
     "for feature in data[\"features\"]:\n",
@@ -150,7 +164,7 @@
    }
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -164,9 +178,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/SplitMap.ipynb
+++ b/examples/SplitMap.ipynb
@@ -15,6 +15,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, TileLayer, SplitMapControl"
    ]
   },
@@ -64,7 +78,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -78,9 +92,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/TileLayer-loading.ipynb
+++ b/examples/TileLayer-loading.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import *\n",
     "from ipywidgets import *\n",
     "\n",
@@ -40,7 +54,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -54,7 +68,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Transform.ipynb
+++ b/examples/Transform.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, Polygon"
    ]
   },
@@ -131,7 +145,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -145,9 +159,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/VectorTiles.ipynb
+++ b/examples/VectorTiles.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, VectorTileLayer, TileLayer"
    ]
   },
@@ -180,7 +194,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -194,7 +208,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/examples/Velocity.ipynb
+++ b/examples/Velocity.ipynb
@@ -17,6 +17,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install(['ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, TileLayer, basemaps\n",
     "from ipyleaflet.velocity import Velocity\n",
     "import xarray as xr"
@@ -94,7 +108,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -108,9 +122,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/WMSLayer.ipynb
+++ b/examples/WMSLayer.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import WMSLayer, Map"
    ]
   },
@@ -34,7 +48,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -48,9 +62,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/WidgetControl.ipynb
+++ b/examples/WidgetControl.ipynb
@@ -6,6 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyleaflet import Map, basemaps, WidgetControl"
    ]
   },
@@ -111,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This greatly expands our JupyterLite examples to include all the examples I saw that were working in JupyterLite.