### PR TITLE
Lazy-load the JupyterLite embedded page in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,6 @@
 Introduction to ipyleaflet
 ==========================
+
 Ipyleaflet is a `Jupyter widget <https://ipywidgets.readthedocs.io>`_ for
 `Leaflet.js <https://leafletjs.com/>`_ , enabling interactive maps in the
 Jupyter notebook. Every object in ipyleaflet (including the Map, TileLayers, Layers,
@@ -11,10 +12,16 @@ Python or from the browser.
 
 Try it online
 -------------
+
 .. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
    :target: ./lite/lab?path=ipyleaflet.ipynb
 
 You can try ipyleaflet below, or open many other live examples in a new browser tab with : `JupyterLite <./lite/lab?path=ipyleaflet.ipynb>`_ or `RetroLite <./lite/retro/tree>`_.
+
+.. retrolite:: ipyleaflet.ipynb
+   :width: 100%
+   :height: 810px
+   :prompt: Try Retrolite!
 
 
 Table of Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ You can try ipyleaflet below, or open many other live examples in a new browser 
 .. retrolite:: ipyleaflet.ipynb
    :width: 100%
    :height: 810px
-   :prompt: Try Retrolite!
+   :prompt: Try ipyleaflet!
 
 
 Table of Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,14 +11,11 @@ Python or from the browser.
 
 Try it online
 -------------
-
 .. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
    :target: ./lite/lab?path=ipyleaflet.ipynb
 
-You can try ipyleaflet below, or open many other live examples in a new browser tab with
-`JupyterLite <./lite/lab?path=ipyleaflet.ipynb>`_ or `RetroLite <./lite/retro/tree>`_.
+You can try ipyleaflet below, or open many other live examples in a new browser tab with : `JupyterLite <./lite/lab?path=ipyleaflet.ipynb>`_ or `RetroLite <./lite/retro/tree>`_.
 
-.. retrolite:: ipyleaflet.ipynb
 
 Table of Contents
 -----------------


### PR DESCRIPTION
Remove the retrolite directive in the documentation, since there are already the links and the buttons to click and make an online try.