### PR TITLE
Update Binder link in the Usage section of the docs

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -47,4 +47,4 @@ Please check out the `traitlets documentation <https://traitlets.readthedocs.io/
 You can try ipyleaflet online using binder, no need to install anything on your computer:
 
 .. image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/stable?filepath=examples
+    :target: https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/stable?urlpath=lab%2Ftree%2Fexamples


### PR DESCRIPTION
Update the Binder link in the Usage section of the docs to be the same as the one in the README:

https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/stable?urlpath=lab%2Ftree%2Fexamples

This will also open JupyterLab by default instead of the classic notebook.