### PR TITLE
Add support for `as_leaflet_layer` in `Map.add`

### DIFF
--- a/docs/source/layers/index.rst
+++ b/docs/source/layers/index.rst
@@ -29,4 +29,4 @@ Layers
     choropleth
     vector_tile.rst
     wkt_layer
-
+    layer_like

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -4,7 +4,7 @@ Layer-Like Objects
 :class:`ipyleaflet.Map`'s :func:`ipyleaflet.Map.add` method supports
 "layer-like" objects; meaning any object with an ``as_leaflet_layer`` method.
 This interface can be especially useful for downstream developers who want
-their users to more easily be able to add thier objects to an
+their users to more easily be able to add their objects to an
 :class:`ipyleaflet.Map`.
 
 Example

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -24,17 +24,9 @@ Here is a simple example of creating a custom data class to hold heatmap data
 
   class MyHeatMap:
       def __init__(self, points, values, radius=20):
-          self._points = points
-          self._values = values
-          self._radius = 20
-
-      @property
-      def points(self):
-          return self._points
-
-      @property
-      def values(self):
-          return self._counts
+          self.points = points
+          self.values = values
+          self.radius = 20
 
       @property
       def data(self):
@@ -44,21 +36,26 @@ Here is a simple example of creating a custom data class to hold heatmap data
           from ipyleaflet import Heatmap
           return Heatmap(
               locations=self.data.tolist(),
-              radius=self._radius,
+              radius=self.radius,
           )
+
+We can now use that custom data class and because it has an
+``as_leaflet_layer`` interface, we can pass the object directly to
+:func:`ipyleaflet.Map.add`.
+
 
 .. jupyter-execute::
 
   from ipyleaflet import Map
 
   n = 1000
-  d = MyHeatMap(
+  data = MyHeatMap(
       np.random.uniform(-80, 80, (n, 2)),
       np.random.uniform(0, 1000, n),
   )
 
   m = Map(center=(0, 0), zoom=2)
-  m.add_layer(d.as_leaflet_layer())
+  m.add(data)
   m
 
 

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -65,4 +65,4 @@ External Examples
 The following external libraries are working to implement this new interface
 
 - `localtileserver <https://github.com/banesullivan/localtileserver>`_: a dynamic tile server built for visualizing large geospatial images/rasters with ipyleaflet.
-- `xarray-leaflet <https://github.com/davidbrochart/xarray_leaflet>`_: an xarray extension for tiled map plotting, based on ipyleaflet.
+- `xarray-leaflet <https://github.com/xarray-contrib/xarray_leaflet>`_: an xarray extension for tiled map plotting, based on ipyleaflet.

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -1,0 +1,71 @@
+Layer-Like Objects
+==================
+
+:class:`ipyleaflet.Map`'s :func:`ipyleaflet.Map.add` method supports
+"layer-like" objects; meaning any object with an ``as_leaflet_layer`` method.
+This interface can be especially useful for downstream developers who want
+their users to more easily be able to add thier objects to an
+:class:`ipyleaflet.Map`.
+
+Example
+-------
+
+Downstream objects should implement an ``as_leaflet_layer`` method that returns
+an ``ipyleaflet`` type capable of being added to the ``Map``.
+
+Here is a simple example of creating a custom data class to hold heatmap data
+(coordinates with some numerical value).
+
+
+.. jupyter-execute::
+
+  import numpy as np
+
+
+  class MyHeatMap:
+      def __init__(self, points, values, radius=20):
+          self._points = points
+          self._values = values
+          self._radius = 20
+
+      @property
+      def points(self):
+          return self._points
+
+      @property
+      def values(self):
+          return self._counts
+
+      @property
+      def data(self):
+          return np.column_stack((self.points, self.values))
+
+      def as_leaflet_layer(self):
+          from ipyleaflet import Heatmap
+          return Heatmap(
+              locations=self.data.tolist(),
+              radius=self._radius,
+          )
+
+.. jupyter-execute::
+
+  from ipyleaflet import Map
+
+  n = 1000
+  d = MyHeatMap(
+      np.random.uniform(-80, 80, (n, 2)),
+      np.random.uniform(0, 1000, n),
+  )
+
+  m = Map(center=(0, 0), zoom=2)
+  m.add_layer(d.as_leaflet_layer())
+  m
+
+
+External Examples
+-----------------
+
+The following external libraries are working to implement this new interface
+
+- `localtileserver <https://github.com/banesullivan/localtileserver>`_: a dynamic tile server built for visualizing large geospatial images/rasters with ipyleaflet.
+- `xarray-leaflet <https://github.com/davidbrochart/xarray_leaflet>`_: an xarray extension for tiled map plotting, based on ipyleaflet.

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -26,7 +26,7 @@ Here is a simple example of creating a custom data class to hold heatmap data
       def __init__(self, points, values, radius=20):
           self.points = points
           self.values = values
-          self.radius = 20
+          self.radius = radius
 
       @property
       def data(self):

--- a/docs/source/layers/layer_like.rst
+++ b/docs/source/layers/layer_like.rst
@@ -1,7 +1,7 @@
 Layer-Like Objects
 ==================
 
-:class:`ipyleaflet.Map`'s :func:`ipyleaflet.Map.add` method supports
+The :func:`ipyleaflet.Map.add` method supports
 "layer-like" objects; meaning any object with an ``as_leaflet_layer`` method.
 This interface can be especially useful for downstream developers who want
 their users to more easily be able to add their objects to an

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1165,7 +1165,9 @@ class LayerGroup(Layer):
         Parameters
         ----------
         layer: layer instance
-            The new layer to include in the group.
+            The new layer to include in the group. This can also be an object
+            with an ``as_leaflet_layer`` method which generates a compatible
+            layer type.
         """
 
         if isinstance(layer, dict):

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1170,6 +1170,8 @@ class LayerGroup(Layer):
 
         if isinstance(layer, dict):
             layer = basemap_to_tiles(layer)
+        elif hasattr(layer, 'as_leaflet_layer'):
+            layer = layer.as_leaflet_layer()
         if layer.model_id in self._layer_ids:
             raise LayerException('layer already in layergroup: %r' % layer)
         self.layers = tuple([layer for layer in self.layers] + [layer])


### PR DESCRIPTION
I use `ipyleaflet` a ton with [localtileserver](https://github.com/banesullivan/localtileserver) and I was thinking it'd be convenient if `ipyleaflet.Map`'s `add()` method supported passing objects with an `as_leaflet_layer()` interface. 

There may be better/cleaner ways to do this, so suggestions are welcome! But, my end goal is to make it easier to go from raster file path to `ipyleaflet.Map` showing tiles like:

```py
from localtileserver import TileClient
from ipyleaflet import Map

client = TileClient('path/to/geo.tif')  # <--- will have `as_leaflet_layer` method

m = Map(center=client.center(), zoom=client.default_zoom)
m.add_layer(client)
m
```