### PR TITLE
Remove HikeBike basemap from the examples

### DIFF
--- a/docs/source/map_and_basemaps/basemaps.rst
+++ b/docs/source/map_and_basemaps/basemaps.rst
@@ -66,12 +66,6 @@ These basemaps are coming from the `xyzservices <https://xyzservices.readthedocs
     Map(basemap=basemaps.Esri.NatGeoWorldMap, center=center, zoom=zoom)
 
 
-.. jupyter-execute::
-
-    Map(basemap=basemaps.HikeBike.HikeBike, center=center, zoom=zoom)
-
-
-
 
 .. jupyter-execute::
 


### PR DESCRIPTION
Remove HikeBike basemap from the examples shown in the documentation, since it seems not to be maintained anymore.