### PR TITLE
Fix map not displaying in jupyterlite.

### DIFF
--- a/docs/source/ipyleaflet.ipynb
+++ b/docs/source/ipyleaflet.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "import piplite\n",
-    "await piplite.install('ipyleaflet')"
+    "await piplite.install('ipyleaflet == 0.17')"
    ]
   },
   {


### PR DESCRIPTION
Fix issue https://github.com/jupyter-widgets/ipyleaflet/issues/1020. The first solution proposed by @jtpio in this issue is implemented, that is "pinning the version with piplite.install('ipyleaflet==0.17') in the notebook."
