### PR TITLE
Restrict ipywidgets version in CI

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -26,7 +26,7 @@ jobs:
           channels: conda-forge
 
       - name: Mamba install dependencies
-        run: mamba install python=${{ matrix.python-version }} pip nodejs=16 flake8 jupyterlab ipywidgets jupyter-packaging~=0.7.9
+        run: mamba install python=${{ matrix.python-version }} pip nodejs=16 flake8 jupyterlab ipywidgets=7 jupyter-packaging~=0.7.9
 
       - name: Install ipyleaflet
         run: pip install .


### PR DESCRIPTION
Just trying to see if I can replicate the UI tests failure from https://github.com/jupyter-widgets/ipyleaflet/pull/968