### PR TITLE
Add a browser entry point in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "author": "Project Jupyter",
   "main": "src/index.js",
+  "browser": "dist/index.js",
   "scripts": {
     "build": "webpack && jupyter labextension build .",
     "clean": "rimraf dist/ && rimraf ../ipyleaflet/labextension/ && rimraf ../ipyleaflet/nbextension",


### PR DESCRIPTION
By default, if we want to use ipyleaflet by itself in the browser (like voila, etc.), we want to serve up the AMD module. This points the default browser import to the AMD module. jsdelivr recognizes this, and we'll see if unpkg recognizes it too.