### PR TITLE
Revert change from #965 that sets the default zoom to None

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -2356,7 +2356,7 @@ class Map(DOMWidget, InteractMixin):
 
     # Map options
     center = List(def_loc).tag(sync=True, o=True)
-    zoom = CFloat(default_value=None, allow_none=True).tag(sync=True, o=True)
+    zoom = CFloat(12).tag(sync=True, o=True)
     max_zoom = CFloat(default_value=None, allow_none=True).tag(sync=True, o=True)
     min_zoom = CFloat(default_value=None, allow_none=True).tag(sync=True, o=True)
     zoom_delta = CFloat(1).tag(sync=True, o=True)


### PR DESCRIPTION
This was breaking the map widget when creating a map without setting an initial zoom level. 
Fix #1065 

```python
from ipyleaflet import Map
display(Map())
```