### PR TITLE
Update to JupyterLite 0.1.0b17

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pip:
     - ..
     - jupyterlite-sphinx
-    - jupyterlite>=0.1.0b9
+    - jupyterlite==0.1.0b17

--- a/docs/jupyterlite_config.json
+++ b/docs/jupyterlite_config.json
@@ -4,7 +4,9 @@
         "https://files.pythonhosted.org/packages/py3/j/jupyterlab-widgets/jupyterlab_widgets-1.1.1-py3-none-any.whl",
         "https://files.pythonhosted.org/packages/py2.py3/i/ipyleaflet/ipyleaflet-0.17.0-py2.py3-none-any.whl"
       ],
-      "ignore_sys_prefix": true,
+      "ignore_sys_prefix": true
+    },
+    "PipliteAddon": {
       "piplite_urls": [
         "https://files.pythonhosted.org/packages/py2.py3/i/ipyleaflet/ipyleaflet-0.17.0-py2.py3-none-any.whl",
         "https://files.pythonhosted.org/packages/py2.py3/i/ipython-genutils/ipython_genutils-0.2.0-py2.py3-none-any.whl",


### PR DESCRIPTION
With JupyterLite `0.1.0b17`, the `piplite_urls` configuration has changed and should now be put under the `PipliteAddon` field: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b17

- [x] Update to `jupyterlite==0.1.0b17` (strict pin for now)
- [x] Update the `piplite_urls` configuration