### PR TITLE
Add fetch_options for VectorTileLayer

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -963,6 +963,8 @@ class VectorTileLayer(Layer):
         Vector tile service attribution.
     vector_tile_layer_styles: dict, default {}
         CSS Styles to apply to the vector data.
+    fetch_options: dict, default {}
+        Options passed to `fetch`, e.g. {credentials: 'same-origin'} to send cookie for the current domain.
     """
 
     _view_name = Unicode('LeafletVectorTileLayerView').tag(sync=True)
@@ -972,6 +974,8 @@ class VectorTileLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
 
     vector_tile_layer_styles = Dict().tag(sync=True, o=True)
+
+    fetch_options = Dict().tag(sync=True, o=True)
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/js/src/layers/VectorTileLayer.js
+++ b/js/src/layers/VectorTileLayer.js
@@ -11,6 +11,7 @@ export class LeafletVectorTileLayerModel extends layer.LeafletLayerModel {
       _model_name: 'LeafletVectorTileLayerModel',
       url: '',
       vectorTileLayerStyles: {},
+      fetchOptions: {},
     };
   }
 }


### PR DESCRIPTION
Related to [this issue](https://github.com/jupyter-widgets/ipyleaflet/issues/802), this PR adds `fetch_options` to `VectorTileLayer`, allowing credentials to be added to vector tile requests.

For example:
```python
lyr = ipyleaflet.VectorTileLayer(
    url=url,
    fetch_options={
        "credentials": "include"
    }
)
```
...which would allow cookies to be included in vector tile requests.

I've tested these changes manually, and they seem to work.