### PR TITLE
fix: make the layer group visibility togglable

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1211,12 +1211,15 @@ class LayerGroup(Layer):
     ----------
     layers: list, default []
         List of layers to include in the group.
+    visible: bool, default True
+        the visibility of the layer on the map
     """
 
     _view_name = Unicode('LeafletLayerGroupView').tag(sync=True)
     _model_name = Unicode('LeafletLayerGroupModel').tag(sync=True)
 
     layers = Tuple().tag(trait=Instance(Layer), sync=True, **widget_serialization)
+    visible = Bool(True).tag(sync=True)
 
     _layer_ids = List()
 
@@ -1340,6 +1343,11 @@ class LayerGroup(Layer):
     def clear(self):
         """Remove all layers from the group."""
         self.layers = ()
+
+    @observe("visible")
+    def toggle_markers(self, visible):
+        """Switch the layers visibility according to the master LayerGroup."""
+        [setattr(layer, "visible", visible["new"]) for layer in self.layers]
 
 
 class FeatureGroup(LayerGroup):


### PR DESCRIPTION
Fix https://github.com/jupyter-widgets/ipyleaflet/issues/1118

In this PR I added a visible boolean trait to the LayerGroup. When updated, all the underlying laayers are changed accordingly allowing the user to hide all layers with 1 line:

```python
layer_group.visible = False
```

Could you let me know if it makes sense for you before I code tests and run linting process ?