### PR TITLE
Sanitize `style` attribute in DrawControl.js for `data` attribute serialization

### DIFF
--- a/js/src/controls/DrawControl.js
+++ b/js/src/controls/DrawControl.js
@@ -141,7 +141,10 @@ export class LeafletDrawControlView extends control.LeafletControlView {
     let newData = [];
     this.feature_group.eachLayer((layer) => {
       const geoJson = layer.toGeoJSON();
-      geoJson.properties.style = layer.options;
+      // Sanitize layer options for serialization via `structuredClone`:
+      // https://web.dev/structured-clone/#features-and-limitations
+      const sanitizedLayerOptions = JSON.parse(JSON.stringify(layer.options));
+      geoJson.properties.style = sanitizedLayerOptions;
       newData.push(geoJson);
     });
     this.model.set('data', newData);


### PR DESCRIPTION
- Fixes #1119 1119

- The main issue is that a `style()` function is added to the GeoJSON object `style` property in `create_obj()`, which triggers an error when the `data` attribute is serialized here: https://github.com/jupyter-widgets/ipywidgets/blob/e1718c2b3bf0b143580ef87f71c55fbc6ed50a77/packages/base/src/widget.ts#L587

- This is because `structuredClone` throws an error for functions: https://web.dev/structured-clone/#features-and-limitations. While the article mentions drawbacks for using `JSON.parse(JSON.stringify(...))`, I believe that this component does not produce any non-primitive properties, so this is a valid strategy for removing offending lines.

- Tested by placing a breakpoint and testing directly on the browser and then building a local ipyleaflet in Jupyter Lab.