### PR TITLE
Add support for PMTiles

### DIFF
--- a/examples/PMTiles.ipynb
+++ b/examples/PMTiles.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for JupyterLite\n",
+    "try:\n",
+    "    import piplite\n",
+    "    await piplite.install('ipyleaflet')\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import Map, basemaps, PMTilesLayer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=[52.963529, 4.776306], zoom=7, basemap=basemaps.CartoDB.DarkMatter, scroll_wheel_zoom=True)\n",
+    "m.layout.height = '600px'\n",
+    "\n",
+    "vl = PMTilesLayer(url=\"https://storage.googleapis.com/ahp-research/overture/pmtiles/overture.pmtiles\", \n",
+    "    style = {\n",
+    "        \"layers\": [\n",
+    "            {\n",
+    "                \"id\": \"admins\",\n",
+    "                \"source\": \"example_source\",\n",
+    "                \"source-layer\": \"admins\",\n",
+    "                \"type\": \"fill\",\n",
+    "                \"paint\": {\"fill-color\": \"#BDD3C7\", \"fill-opacity\": 0.1},\n",
+    "            },\n",
+    "            {\n",
+    "                \"id\": \"buildings\",\n",
+    "                \"source\": \"example_source\",\n",
+    "                \"source-layer\": \"buildings\",\n",
+    "                \"type\": \"fill\",\n",
+    "                \"paint\": {\"fill-color\": \"#FFFFB3\", \"fill-opacity\": 0.5},\n",
+    "            },\n",
+    "            {\n",
+    "                \"id\": \"places\",\n",
+    "                \"source\": \"example_source\",\n",
+    "                \"source-layer\": \"places\",\n",
+    "                \"type\": \"fill\",\n",
+    "                \"paint\": {\"fill-color\": \"#BEBADA\", \"fill-opacity\": 0.5},\n",
+    "            },\n",
+    "            {\n",
+    "                \"id\": \"roads\",\n",
+    "                \"source\": \"example_source\",\n",
+    "                \"source-layer\": \"roads\",\n",
+    "                \"type\": \"line\",\n",
+    "                \"paint\": {\"line-color\": \"#FB8072\"},\n",
+    "            },\n",
+    "        ],\n",
+    "    })\n",
+    "m.add(vl)\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1010,6 +1010,7 @@ class PMTilesLayer(Layer):
         """
         self.send({'msg': 'add_inspector'})
 
+
 class VectorLayer(Layer):
     """VectorLayer abstract class."""
 

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -991,9 +991,9 @@ class PMTilesLayer(Layer):
     Attributes
     ----------
     url: string, default ""
-        Url to the vector tile service.
+        Url to the PMTiles archive.
     attribution: string, default ""
-        Vector tile service attribution.
+        PMTiles archive attribution.
     style: dict, default {}
         CSS Styles to apply to the vector data.
     """

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -982,6 +982,30 @@ class VectorTileLayer(Layer):
         self.send({'msg': 'redraw'})
 
 
+class PMTilesLayer(Layer):
+    """PMTilesLayer class, with Layer as parent class.
+
+    PMTiles layer.
+
+
+    Attributes
+    ----------
+    url: string, default ""
+        Url to the vector tile service.
+    attribution: string, default ""
+        Vector tile service attribution.
+    style: dict, default {}
+        CSS Styles to apply to the vector data.
+    """
+
+    _view_name = Unicode('LeafletPMTilesLayerView').tag(sync=True)
+    _model_name = Unicode('LeafletPMTilesLayerModel').tag(sync=True)
+
+    url = Unicode().tag(sync=True, o=True)
+    attribution = Unicode().tag(sync=True, o=True)
+    style = Dict().tag(sync=True, o=True)
+
+
 class VectorLayer(Layer):
     """VectorLayer abstract class."""
 

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -1005,6 +1005,10 @@ class PMTilesLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
     style = Dict().tag(sync=True, o=True)
 
+    def add_inspector(self):
+        """Add an inspector to the layer.
+        """
+        self.send({'msg': 'add_inspector'})
 
 class VectorLayer(Layer):
     """VectorLayer abstract class."""

--- a/js/package.json
+++ b/js/package.json
@@ -49,8 +49,8 @@
     "spin.js": "^4.1.0",
     "stream-browserify": "^3.0.0",
     "pmtiles": "^2.5.0",
-    "maplibre-lib": "^2.2.1",
-    "maplibre-leaflet": "^0.0.17"
+    "maplibre-gl": "^2.2.1",
+    "maplibre-gl-leaflet": "^0.0.17"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -48,8 +48,7 @@
     "proj4leaflet": "^1.0.1",
     "spin.js": "^4.1.0",
     "stream-browserify": "^3.0.0",
-    "pmtiles": "^2.7.1",
-    "maplibre-gl": "^2.4.0"
+    "protomaps-leaflet": "^1.24.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -47,7 +47,10 @@
     "proj4": "^2.6.0",
     "proj4leaflet": "^1.0.1",
     "spin.js": "^4.1.0",
-    "stream-browserify": "^3.0.0"
+    "stream-browserify": "^3.0.0",
+    "pmtiles": "^2.5.0",
+    "maplibre-lib": "^2.2.1",
+    "maplibre-leaflet": "^0.0.17"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -48,9 +48,8 @@
     "proj4leaflet": "^1.0.1",
     "spin.js": "^4.1.0",
     "stream-browserify": "^3.0.0",
-    "pmtiles": "^2.5.0",
-    "maplibre-gl": "^2.2.1",
-    "maplibre-gl-leaflet": "^0.0.17"
+    "pmtiles": "^2.7.1",
+    "maplibre-gl": "^2.4.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.6.0",

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -9,6 +9,7 @@ export * from './layers/AwesomeIcon.js';
 export * from './layers/Popup.js';
 export * from './layers/RasterLayer.js';
 export * from './layers/TileLayer.js';
+export * from './layers/PMTilesLayer.js';
 export * from './layers/VectorTileLayer.js';
 export * from './layers/LocalTileLayer.js';
 export * from './layers/WMSLayer.js';

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -23,8 +23,7 @@ export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
     }
 
     create_obj() {
-        this.obj = protomapsL.leafletLayer({url:this.model.get('url')})
-        
+        this.obj = L.protomapsL.leafletLayer({url:this.model.get('url')})
     }
 
     model_events() {

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -23,7 +23,9 @@ export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
     }
 
     create_obj() {
-        this.obj = L.protomapsL.leafletLayer({url:this.model.get('url')})
+        this.obj = L.protomapsL.leafletLayer({
+            url:this.model.get('url')
+        })
     }
 
     model_events() {

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 const layer = require('./Layer.js');
+const protomapsL = require('protomaps-leaflet');
 
 export class LeafletPMTilesLayerModel extends layer.LeafletLayerModel {
     defaults() {
@@ -18,8 +19,12 @@ export class LeafletPMTilesLayerModel extends layer.LeafletLayerModel {
 
 export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
     create_obj() {
-        this.obj = L.protomapsL.leafletLayer(this.model.get('url'), this.get_options());
-        // this.model.on('msg:custom', this.handle_message.bind(this));
+      var options = {
+        ...this.get_options(),
+        url: this.model.get('url'),
+        ...protomapsL.json_style(this.model.get('style')),
+      };
+      this.obj = protomapsL.leafletLayer(options);
       }
     
       model_events() {

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -1,0 +1,55 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+const layer = require('./Layer.js');
+
+export class LeafletPMTilesLayerModel extends layer.LeafletLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: 'LeafletPMTilesLayerView',
+            _model_name: 'LeafletPMTilesLayerModel',
+            url: '',
+            style: {},
+        };
+    }
+}
+
+export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
+    render() {
+        this.create_obj();
+        this.listenTo(this.model, 'change:url', this.url_changed.bind(this));
+        this.listenTo(this.model, 'change:style', this.style_changed.bind(this));
+    }
+
+    create_obj() {
+        var protocol = new pmtiles.Protocol();
+        maplibregl.addProtocol("pmtiles", protocol.tile);
+        
+        var mapStyle = {
+            ...this.model.get('style'),
+            sources: {
+                ...this.model.get('style').sources,
+                "pmtiles_source": {
+                    "type": "vector",
+                    "url": "pmtiles://" + this.model.get('url')
+                }
+            }
+        };
+        
+        this.obj = L.maplibreGL({
+            style: mapStyle
+        });
+    }
+
+    url_changed() {
+        var newUrl = "pmtiles://" + this.model.get('url');
+        var currentStyle = this.obj.getStyle();
+        currentStyle.sources["pmtiles_source"].url = newUrl;
+        this.obj.setStyle(currentStyle);
+    }
+
+    style_changed() {
+        this.obj.setStyle(this.model.get('style'));
+    }
+}

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -10,25 +10,19 @@ export class LeafletPMTilesLayerModel extends layer.LeafletLayerModel {
             _view_name: 'LeafletPMTilesLayerView',
             _model_name: 'LeafletPMTilesLayerModel',
             url: '',
+            attribution: '',
             style: {},
         };
     }
 }
 
 export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
-    render() {
-        this.create_obj();
-        this.listenTo(this.model, 'change:url', this.url_changed.bind(this));
-        this.listenTo(this.model, 'change:style', this.style_changed.bind(this));
-    }
-
     create_obj() {
-        this.obj = L.protomapsL.leafletLayer({
-            url:this.model.get('url')
-        })
-    }
-
-    model_events() {
+        this.obj = L.protomapsL.leafletLayer(this.model.get('url'), this.get_options());
+        // this.model.on('msg:custom', this.handle_message.bind(this));
+      }
+    
+      model_events() {
         super.model_events();
         this.listenTo(
           this.model,
@@ -40,7 +34,10 @@ export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
         );
       }
 
-    style_changed() {
-        this.obj.setStyle(this.model.get('style'));
+      handle_message(content) {
+        if (content.msg == 'add_inspector') {
+          this.obj.addInspector(this.map_view.obj);
+        }
+      }
     }
-}
+    

--- a/js/src/layers/PMTilesLayer.js
+++ b/js/src/layers/PMTilesLayer.js
@@ -23,31 +23,21 @@ export class LeafletPMTilesLayerView extends layer.LeafletLayerView {
     }
 
     create_obj() {
-        var protocol = new pmtiles.Protocol();
-        maplibregl.addProtocol("pmtiles", protocol.tile);
+        this.obj = protomapsL.leafletLayer({url:this.model.get('url')})
         
-        var mapStyle = {
-            ...this.model.get('style'),
-            sources: {
-                ...this.model.get('style').sources,
-                "pmtiles_source": {
-                    "type": "vector",
-                    "url": "pmtiles://" + this.model.get('url')
-                }
-            }
-        };
-        
-        this.obj = L.maplibreGL({
-            style: mapStyle
-        });
     }
 
-    url_changed() {
-        var newUrl = "pmtiles://" + this.model.get('url');
-        var currentStyle = this.obj.getStyle();
-        currentStyle.sources["pmtiles_source"].url = newUrl;
-        this.obj.setStyle(currentStyle);
-    }
+    model_events() {
+        super.model_events();
+        this.listenTo(
+          this.model,
+          'change:url',
+          function () {
+            this.obj.setUrl(this.model.get('url'));
+          },
+          this
+        );
+      }
 
     style_changed() {
         this.obj.setStyle(this.model.get('style'));

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -16,6 +16,9 @@ require('leaflet-fullscreen');
 require('leaflet-transform');
 require('leaflet.awesome-markers');
 require('leaflet-search');
+require('pmtiles');
+require('maplibre-lib');
+require('maplibre-leaflet');
 
 // Monkey patch GridLayer for smoother URL updates
 L.patchGridLayer = function (layer) {

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -16,8 +16,7 @@ require('leaflet-fullscreen');
 require('leaflet-transform');
 require('leaflet.awesome-markers');
 require('leaflet-search');
-require('pmtiles');
-require('maplibre-gl');
+require('protomaps-leaflet');
 
 // Monkey patch GridLayer for smoother URL updates
 L.patchGridLayer = function (layer) {

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -17,8 +17,8 @@ require('leaflet-transform');
 require('leaflet.awesome-markers');
 require('leaflet-search');
 require('pmtiles');
-require('maplibre-lib');
-require('maplibre-leaflet');
+require('maplibre-gl');
+require('maplibre-gl-leaflet');
 
 // Monkey patch GridLayer for smoother URL updates
 L.patchGridLayer = function (layer) {

--- a/js/src/leaflet.js
+++ b/js/src/leaflet.js
@@ -18,7 +18,6 @@ require('leaflet.awesome-markers');
 require('leaflet-search');
 require('pmtiles');
 require('maplibre-gl');
-require('maplibre-gl-leaflet');
 
 // Monkey patch GridLayer for smoother URL updates
 L.patchGridLayer = function (layer) {


### PR DESCRIPTION
[PMTiles](https://github.com/protomaps/PMTiles) is a single-file archive format for tiled data. A PMTiles archive can be hosted on a commodity storage platform such as S3, and enables low-cost, zero-maintenance map applications that are "serverless" - free of a custom tile backend or third party provider. 

Currently, it is challenging to render large vector datasets with ipyleaflet. PMTiles can be a great option for rendering large vector datasets with ipyleaflet. The [folium-pmtiles](https://github.com/jtmiclat/folium-pmtiles) package supports rendering PMTiles with folium. See below for an example. 

This PR tries to add ipyleaflet support for PMTiles. However, I have very limited JavaScript knowledge. I need your help. Thanks. 

@martinRenou @davidbrochart @jtmiclat @bdon

https://github.com/protomaps/PMTiles/discussions/209
https://github.com/jupyter-widgets/ipyleaflet/issues/1134

```python
import folium
from folium.elements import JSCSSMixin
from folium.map import Layer
from jinja2 import Template

class PMTilesMapLibreLayer(JSCSSMixin, Layer):
    """Based of
    https://github.com/python-visualization/folium/blob/56d3665fdc9e7280eae1df1262450e53ec4f5a60/folium/plugins/vectorgrid_protobuf.py
    """

    _template = Template(
        """
            {% macro script(this, kwargs) -%}
            let protocol = new pmtiles.Protocol();
            maplibregl.addProtocol("pmtiles", protocol.tile);

           {{ this._parent.get_name() }}.createPane('overlay');
           {{ this._parent.get_name() }}.getPane('overlay').style.zIndex = 650;
           {{ this._parent.get_name() }}.getPane('overlay').style.pointerEvents = 'none';

            var {{ this.get_name() }} = L.maplibreGL({
            pane: 'overlay',
            style: {{ this.style|tojson}}
            }).addTo({{ this._parent.get_name() }});

            {%- endmacro %}
            """
    )
    default_css = [
        ("maplibre_css", "https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.css")
    ]

    default_js = [
        ("pmtiles", "https://unpkg.com/pmtiles@2.5.0/dist/index.js"),
        ("maplibre-lib", "https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.js"),
        (
            "maplibre-leaflet",
            "https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.17/leaflet-maplibre-gl.js",
        ),
    ]

    def __init__(self, url, layer_name=None, style=None, **kwargs):
        self.layer_name = layer_name if layer_name else "PMTilesVector"

        super().__init__(name=self.layer_name, **kwargs)

        self.url = url
        self._name = "PMTilesVector"

        if style is not None:
            self.style = style
        else:
            self.style = {}


m = folium.Map(location=[43.7798, 11.24148], zoom_start=13)
pmtiles_url = "https://open.gishub.org/data/pmtiles/protomaps_firenze.pmtiles"
pmtiles_layer = PMTilesMapLibreLayer(
    "folium_layer_name",
    overlay=True,
    style={
        "version": 8,
        "sources": {
            "example_source": {
                "type": "vector",
                "url": "pmtiles://" + pmtiles_url,
                "attribution": '<a href="https://protomaps.com">Protomaps</a> © <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>',
            }
        },
        "layers": [
            {
                "id": "buildings",
                "source": "example_source",
                "source-layer": "landuse",
                "type": "fill",
                "paint": {"fill-color": "steelblue"},
            },
            {
                "id": "roads",
                "source": "example_source",
                "source-layer": "roads",
                "type": "line",
                "paint": {"line-color": "black"},
            },
        ],
    },
)
m.add_child(pmtiles_layer)
folium.LayerControl().add_to(m)
m
```
![image](https://github.com/jupyter-widgets/ipyleaflet/assets/5016453/0c4abec1-8666-4cd2-afb3-2a0621d9e410)