### PR TITLE
fix examples/KML.ipynb to work with recent versions of geopandas

### DIFF
--- a/examples/KML.ipynb
+++ b/examples/KML.ipynb
@@ -16,7 +16,8 @@
    "outputs": [],
    "source": [
     "from ipyleaflet import Map, GeoData\n",
-    "import geopandas as gpd"
+    "import geopandas as gpd\n",
+    "import fiona"
    ]
   },
   {
@@ -29,7 +30,7 @@
     "\n",
     "m = Map(center=[41.8781, -87.6298], zoom=4)\n",
     "\n",
-    "gpd.io.file.fiona.drvsupport.supported_drivers[\"KML\"] = \"rw\"\n",
+    "fiona.drvsupport.supported_drivers[\"KML\"] = \"rw\"\n",
     "us_states = gpd.read_file(\"data/us-states.kml\", driver=\"KML\")\n",
     "\n",
     "geo_data = GeoData(\n",
@@ -47,11 +48,18 @@
     "m.add(geo_data)\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -65,7 +73,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 `examples/KML.ipynb` is broken in v 0.17.4 of ipyleaflet -- you can verify this problem by [running the notebook in mybinder.org](https://mybinder.org/v2/gh/jupyter-widgets/ipyleaflet/0.17.4?labpath=examples%2FKML.ipynb) and see the following error:
 
![image](https://github.com/jupyter-widgets/ipyleaflet/assets/153266/c33a56e1-a7fe-449c-9c36-72e0219f2dba)

I implemented a fix based on the discussion at [geopandas - AttributeError: 'NoneType' object has no attribute 'drvsupport' when using Fiona driver - Stack Overflow](https://stackoverflow.com/questions/72960340/attributeerror-nonetype-object-has-no-attribute-drvsupport-when-using-fiona).

You can also see how this PR fixes the problem by [running the notebook in this branch on mybinder.org](https://mybinder.org/v2/gh/rdhyee/ipyleaflet/fix-KML-example?labpath=examples%2FKML.ipynb):

![image](https://github.com/jupyter-widgets/ipyleaflet/assets/153266/f52afed0-efb1-4306-8da6-ff6ad5b42ec7)
