### PR TITLE
fix: Support for Python 3.8 was removed

### DIFF
--- a/python/ipyleaflet/pyproject.toml
+++ b/python/ipyleaflet/pyproject.toml
@@ -22,11 +22,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Multimedia :: Graphics",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = [
     "ipyleaflet_core",
     "jupyter_leaflet",

--- a/python/ipyleaflet_core/pyproject.toml
+++ b/python/ipyleaflet_core/pyproject.toml
@@ -22,11 +22,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Multimedia :: Graphics",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = [
     "ipywidgets>=7.6.0,<9",
     "traittypes>=0.2.1,<3",

--- a/python/jupyter_leaflet/pyproject.toml
+++ b/python/jupyter_leaflet/pyproject.toml
@@ -22,11 +22,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Multimedia :: Graphics",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://github.com/jupyter-widgets/ipyleaflet"


### PR DESCRIPTION
I believe this was done accidentally as a part of the recent larger refactor, since testing is still being done on Python 3.8, while it isn't officially supported.