### PR TITLE
fix: cast this.get_options to support @types/leaflet@1.9.9

### DIFF
--- a/python/jupyter_leaflet/src/layers/Circle.ts
+++ b/python/jupyter_leaflet/src/layers/Circle.ts
@@ -22,7 +22,10 @@ export class LeafletCircleView extends LeafletCircleMarkerView {
   obj: Circle;
 
   create_obj() {
-    this.obj = L.circle(this.model.get('location'), this.get_options());
+    this.obj = L.circle(
+      this.model.get('location'),
+      this.get_options() as L.CircleOptions
+    );
   }
 
   model_events() {

--- a/python/jupyter_leaflet/src/layers/CircleMarker.ts
+++ b/python/jupyter_leaflet/src/layers/CircleMarker.ts
@@ -22,7 +22,10 @@ export class LeafletCircleMarkerView extends LeafletPathView {
   obj: CircleMarker;
 
   create_obj() {
-    this.obj = L.circleMarker(this.model.get('location'), this.get_options());
+    this.obj = L.circleMarker(
+      this.model.get('location'),
+      this.get_options() as L.CircleMarkerOptions
+    );
   }
 
   model_events() {


### PR DESCRIPTION
Fixes two issues encountered during typescript compilation with newest version of `@types/leaflet`, `1.9.9`.