### PR TITLE
fix(docs): GeomanDrawControl was not included in docs navigation

### DIFF
--- a/docs/controls/index.rst
+++ b/docs/controls/index.rst
@@ -11,6 +11,7 @@ Controls
     measure_control
     split_map_control
     draw_control
+    geoman_draw_control
     widget_control
     legend_control
     search_control


### PR DESCRIPTION
The documentation for `GeomanDrawControl` was not linked to from the navigation before.