### PR TITLE
remove broken, deprecated nbextension enable from installation docs

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -7,7 +7,6 @@ Using pip
 .. code:: bash
 
     pip install ipyleaflet
-    jupyter nbextension enable --py --sys-prefix ipyleaflet  # can be skipped for notebook 5.3 and above
 
 Using conda
 -----------
@@ -37,8 +36,8 @@ For a development installation (requires yarn):
     pip install -e .
 
     # If you are developing on Jupyter Notebook
-    jupyter nbextension install --py --symlink --sys-prefix --overwrite ipyleaflet
-    jupyter nbextension enable --py --sys-prefix --overwrite ipyleaflet
+    jupyter nbextension install --py --symlink --sys-prefix --overwrite jupyter_leaflet
+    jupyter nbextension enable --py --sys-prefix jupyter_leaflet
 
     # If you are developing on JupyterLab
     jupyter labextension develop . --overwrite


### PR DESCRIPTION
install docs still suggest

```
jupyter nbextension enable --py --sys-prefix ipyleaflet
```

which doesn't work anymore because nbextension methods moved to `jupyter_leaflet` without deprecation in #1189. It's unclear from #1189 whether breaking the nbextension name was intentional.

xref #1195