### PR TITLE
Improve vector tile layer

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1096,7 +1096,7 @@ class VectorTileLayer(Layer):
         Url to the vector tile service.
     attribution: string, default ""
         Vector tile service attribution.
-    vector_tile_layer_styles: dict or str, default {}
+    vector_tile_layer_styles: dict or string, default {}. If string, it will be parsed as a javascript object (useful for defining styles that depend on properties and/or zoom).
         CSS Styles to apply to the vector data.
     min_zoom: int, default 0
         The minimum zoom level down to which this layer will be displayed (inclusive).

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1114,6 +1114,8 @@ class VectorTileLayer(Layer):
     url = Unicode().tag(sync=True, o=True)
     attribution = Unicode().tag(sync=True, o=True)
 
+    vector_tile_layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
+
     min_zoom = Int(0).tag(sync=True, o=True)
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1096,7 +1096,7 @@ class VectorTileLayer(Layer):
         Url to the vector tile service.
     attribution: string, default ""
         Vector tile service attribution.
-    vector_tile_layer_styles: dict, default {}
+    vector_tile_layer_styles: dict or str, default {}
         CSS Styles to apply to the vector data.
     min_zoom: int, default 0
         The minimum zoom level down to which this layer will be displayed (inclusive).

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1098,6 +1098,14 @@ class VectorTileLayer(Layer):
         Vector tile service attribution.
     vector_tile_layer_styles: dict, default {}
         CSS Styles to apply to the vector data.
+    min_zoom: int, default 0
+        The minimum zoom level down to which this layer will be displayed (inclusive).
+    max_zoom: int, default 18
+        The maximum zoom level up to which this layer will be displayed (inclusive).
+    min_native_zoom: int, default None
+        Minimum zoom number the tile source has available. If it is specified, the tiles on all zoom levels lower than min_native_zoom will be loaded from min_native_zoom level and auto-scaled.
+    max_native_zoom: int, default None
+        Maximum zoom number the tile source has available. If it is specified, the tiles on all zoom levels higher than max_native_zoom will be loaded from max_native_zoom level and auto-scaled.
     """
 
     _view_name = Unicode("LeafletVectorTileLayerView").tag(sync=True)
@@ -1106,7 +1114,10 @@ class VectorTileLayer(Layer):
     url = Unicode().tag(sync=True, o=True)
     attribution = Unicode().tag(sync=True, o=True)
 
-    vector_tile_layer_styles = Dict().tag(sync=True, o=True)
+    min_zoom = Int(0).tag(sync=True, o=True)
+    max_zoom = Int(18).tag(sync=True, o=True)
+    min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
+    max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -16,7 +16,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       min_zoom: 0,
       max_zoom: 18,
       min_native_zoom: null,
-      max_native_zoom: null
+      max_native_zoom: null,
     };
   }
 }
@@ -28,27 +28,26 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     let options = {
       ...this.get_options(),
     };
-    options["rendererFactory"] = L.canvas.tile;
-    
-    let x:any = this.model.get('vectorTileLayerStyles'); 
-    if (typeof x !== 'object'){
-        try{
-        let blobCode = `const jsStyle=${x}; export { jsStyle };`; 
+    options['rendererFactory'] = L.canvas.tile;
+
+    let x: any = this.model.get('vectorTileLayerStyles');
+    if (typeof x !== 'object') {
+      try {
+        let blobCode = `const jsStyle=${x}; export { jsStyle };`;
 
         const blob = new Blob([blobCode], { type: 'text/javascript' });
         const url = URL.createObjectURL(blob);
-        const module = await import(/* webpackIgnore: true*/url);
+        const module = await import(/* webpackIgnore: true*/ url);
         const jsStyle = module.jsStyle;
 
-        options["vectorTileLayerStyles"]=jsStyle;
-        } catch (error){
-            options["vectorTileLayerStyles"]={}
-        }
+        options['vectorTileLayerStyles'] = jsStyle;
+      } catch (error) {
+        options['vectorTileLayerStyles'] = {};
+      }
     }
 
     this.obj = L.vectorGrid.protobuf(this.model.get('url'), options);
     this.model.on('msg:custom', this.handle_message.bind(this));
-
   }
 
   model_events() {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -27,9 +27,10 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
   async create_obj() {
     let options = {
       ...this.get_options(),
-      rendererFactory: L.canvas.tile,
     };
-    let x:any = options["vectorTileLayerStyles"]
+    options["rendererFactory"] = L.canvas.tile;
+    
+    let x:any = this.model.get('vectorTileLayerStyles'); 
     if (typeof x !== 'object'){
         try{
         let blobCode = `const jsStyle=${x}; export { jsStyle };`; 

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -24,13 +24,30 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
 export class LeafletVectorTileLayerView extends LeafletLayerView {
   obj: VectorGrid.Protobuf;
 
-  create_obj() {
-    const options = {
+  async create_obj() {
+    let options = {
       ...this.get_options(),
       rendererFactory: L.canvas.tile,
     };
+    let x:any = options["vectorTileLayerStyles"]
+    if (typeof x !== 'object'){
+        try{
+        let blobCode = `const jsStyle=${x}; export { jsStyle };`; 
+
+        const blob = new Blob([blobCode], { type: 'text/javascript' });
+        const url = URL.createObjectURL(blob);
+        const module = await import(/* webpackIgnore: true*/url);
+        const jsStyle = module.jsStyle;
+
+        options["vectorTileLayerStyles"]=jsStyle;
+        } catch (error){
+            options["vectorTileLayerStyles"]={}
+        }
+    }
+
     this.obj = L.vectorGrid.protobuf(this.model.get('url'), options);
     this.model.on('msg:custom', this.handle_message.bind(this));
+
   }
 
   model_events() {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -13,6 +13,10 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       _model_name: 'LeafletVectorTileLayerModel',
       url: '',
       vectorTileLayerStyles: {},
+      min_zoom: 0,
+      max_zoom: 18,
+      min_native_zoom: null,
+      max_native_zoom: null
     };
   }
 }

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -31,7 +31,7 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     options['rendererFactory'] = L.canvas.tile;
 
     let x: any = this.model.get('vectorTileLayerStyles');
-    if (typeof x !== 'object') {
+    if (typeof x === 'string') {
       try {
         let blobCode = `const jsStyle=${x}; export { jsStyle };`;
 


### PR DESCRIPTION
This PR aims to add the ability to use dynamic styling to `VectorTileLayer`. That is, styling may be defined as a function of `properties` and `zoom`. This is possible with [Leaflet.VectorGrid](https://leaflet.github.io/Leaflet.VectorGrid/vectorgrid-api-docs.html), but is not yet implemented in ipyleaflet, because there is currently no way to define python callbacks that can be used by the leaflet map. 

One compromise is to allow the user to define the javascript code for the dynamic style as a string.

Following the [example from the documentation](https://ipyleaflet.readthedocs.io/en/latest/layers/vector_tile.html), here's a simple dynamic style that the user could define for use with `ipyleaflet.VectorTileLayer`: 

```python
jstyle='''{
    water:{opacity:0},
    places:{opacity:0},
    transit:{opacity:0},
    pois:{opacity:0},
    boundaries:{opacity:0},
    roads:{opacity:0},
    earth:{opacity:0},
    landuse: function(properties, zoom){
        var color = "gray";
        var fill = true;

        if(properties.kind=="forest"){
            color="green";
        }

        if(zoom<10){
            color="purple";
        }

        return {
            color: color,
            fill: fill
        }
        
    }
}
'''
```

it should only show `landuse` in purple for zoom levels less than 10, and otherwise show features as gray, except if they are "forest". 

Here's an animation of the behavior achieved by this PR:

![ipyleaflet_new](https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/43a702e1-939d-41d8-a2f3-1eba0d1ab79f)

Here's another example using my own vector tile layer:

![ipyleaflet_new_pivots](https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/85243dad-5b74-4393-98c5-ac30e4117e59)

Related issue:  #744 

