### PR TITLE
Add basemap model_id to Map._layer_ids attribute

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -2805,6 +2805,7 @@ class Map(DOMWidget, InteractMixin):
         )
 
         basemap.base = True
+        self._layer_ids.append(basemap.model_id)
 
         return (basemap,)
 


### PR DESCRIPTION
When initializing the Map with a basemap, the basemap `model_id` is not added to the `Map._layer_ids` attribute, resulting in an error when trying to removing the basemap from the map. This PR fixes the bug by adding the basemap layer id to the `Map._layer_ids` attribute

```python
import ipyleaflet
m = ipyleaflet.Map()
m
m.remove(m.layers[0])
```

![image](https://github.com/jupyter-widgets/ipyleaflet/assets/5016453/cc7f4cd3-ef98-443f-b139-42d718d7a25e)
