### PR TITLE
Vector tile layer opacity and visible

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1106,6 +1106,10 @@ class VectorTileLayer(Layer):
         Minimum zoom number the tile source has available. If it is specified, the tiles on all zoom levels lower than min_native_zoom will be loaded from min_native_zoom level and auto-scaled.
     max_native_zoom: int, default None
         Maximum zoom number the tile source has available. If it is specified, the tiles on all zoom levels higher than max_native_zoom will be loaded from max_native_zoom level and auto-scaled.
+    opacity: float, default 1.
+        Opacity of the layer between 0. (fully transparent) and 1. (fully opaque).
+    visible: boolean, default True
+        Whether the layer is visible or not.
     """
 
     _view_name = Unicode("LeafletVectorTileLayerView").tag(sync=True)
@@ -1115,7 +1119,8 @@ class VectorTileLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
 
     vector_tile_layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
-
+    opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
     min_zoom = Int(0).tag(sync=True, o=True)
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -17,6 +17,9 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       max_zoom: 18,
       min_native_zoom: null,
       max_native_zoom: null,
+      interactive: true,
+      visible: true,
+      opacity: 1.0,
     };
   }
 }
@@ -29,8 +32,8 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
       ...this.get_options(),
     };
     options['rendererFactory'] = L.canvas.tile;
-
-    let x: any = this.model.get('vectorTileLayerStyles');
+    
+    let x: any = options['vectorTileLayerStyles'];
     if (typeof x === 'string') {
       try {
         let blobCode = `const jsStyle=${x}; export { jsStyle };`;
@@ -54,6 +57,18 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     super.model_events();
     this.listenTo(this.model, 'change:url', () => {
       this.obj.setUrl(this.model.get('url'));
+    });
+    this.listenTo(this.model, 'change:opacity', () => {
+      if (this.model.get('visible')) {
+        this.obj.setOpacity(this.model.get('opacity'));
+      }
+    });
+    this.listenTo(this.model, 'change:visible', () => {
+      if (this.model.get('visible')) {
+        this.obj.setOpacity(this.model.get('opacity'));
+      } else {
+        this.obj.setOpacity(0);
+      }
     });
   }
 

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -32,7 +32,7 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
       ...this.get_options(),
     };
     options['rendererFactory'] = L.canvas.tile;
-    
+
     let x: any = options['vectorTileLayerStyles'];
     if (typeof x === 'string') {
       try {


### PR DESCRIPTION
This PR adds the missing `visible` and `opacity` traits/attributes in vector tile layers, so now it's possible to control the opacity and visibility of these layers using custom widgets.

Here's how it looks like using a custom widget with a checkbox (linked to `visible`) and a slider (linked to `opacity`):

![ipyleaflet_opacity_visible](https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/fc3d2a52-75b8-4e21-b689-0afa7a41b67c)

This solves the downstream leafmap [issue](https://github.com/opengeos/leafmap/issues/747) associated with its custom layer control toolbar:

![leafmap_opacity_visible](https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/acbcc886-8b28-4bfb-b579-2fe8f92da691)

