### PR TITLE
Interactive vector tile layers

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1114,7 +1114,7 @@ class VectorTileLayer(Layer):
         Engine for rendering VectorTileLayers; either 'canvas' or 'svg'. Use 'svg' for interactive layers.
     interactive: boolean, default False
         Whether the layer is interactive or not.
-    get_feature_id: string, default None
+    feature_id: string, default None
         Optional attribute name of a unique feature identifier. 
     """
 
@@ -1133,7 +1133,7 @@ class VectorTileLayer(Layer):
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     renderer = Unicode('svg').tag(sync=True, o=True)
-    get_feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
+    feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
     feature_style = Dict().tag(sync=True)
 
     def redraw(self):

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1110,7 +1110,8 @@ class VectorTileLayer(Layer):
         Opacity of the layer between 0. (fully transparent) and 1. (fully opaque).
     visible: boolean, default True
         Whether the layer is visible or not.
-    renderer_factory: rendererFactory option ('svg' or 'canvas') for L.VectorGrid, default 'svg'
+    renderer_factory: string, default 'svg'
+        Engine for rendering VectorTileLayers; either 'canvas' or 'svg'. Use 'svg' for interactive layers.
     interactive: boolean, default False
         Whether the layer is interactive or not.
     get_feature_id: string, default None
@@ -1141,6 +1142,38 @@ class VectorTileLayer(Layer):
         need to refresh the layer.
         """
         self.send({"msg": "redraw"})
+
+    def set_feature_style(self, id:Int, layer_style:Dict):
+        """Re-symbolize one feature.
+
+        Given the unique ID for a vector features, re-symbolizes that feature across all tiles it appears in. 
+        Reverts the effects of a previous set_feature_style call. get_feature_id must be defined for 
+        set_feature_style to work. 
+
+        Attributes
+        ----------
+        id: int
+            The unique identifier for the feature to re-symbolize
+        layer_styles: dict
+            Style to apply to the feature
+        """
+        self.send({"msg": 
+                   {"setFeatureStyle":
+                    {"id":id, "layerStyle":layer_style}}
+                })
+
+    def reset_feature_style(self, id:Int):
+        """Reset feature style
+
+        Reverts the style to the layer's deafult.
+
+        Attributes
+        ----------
+        id: int
+            The unique identifier for the feature to re-symbolize
+        """
+        self.send({"msg": {"resetFeatureStyle":{"id":id}}})
+
 
 
 class PMTilesLayer(Layer):

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1096,7 +1096,7 @@ class VectorTileLayer(Layer):
         Url to the vector tile service.
     attribution: string, default ""
         Vector tile service attribution.
-    vector_tile_layer_styles: dict or string, default {}. If string, it will be parsed as a javascript object (useful for defining styles that depend on properties and/or zoom).
+    layer_styles: dict or string, default {}. If string, it will be parsed as a javascript object (useful for defining styles that depend on properties and/or zoom).
         CSS Styles to apply to the vector data.
     min_zoom: int, default 0
         The minimum zoom level down to which this layer will be displayed (inclusive).
@@ -1124,7 +1124,7 @@ class VectorTileLayer(Layer):
     url = Unicode().tag(sync=True, o=True)
     attribution = Unicode().tag(sync=True, o=True)
 
-    vector_tile_layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
+    layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
     opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True,o=True)
     visible = Bool(True).tag(sync=True, o=True)
     interactive = Bool(False).tag(sync=True, o=True)

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1113,6 +1113,8 @@ class VectorTileLayer(Layer):
     renderer_factory: rendererFactory option ('svg' or 'canvas') for L.VectorGrid, default 'svg'
     interactive: boolean, default False
         Whether the layer is interactive or not.
+    get_feature_id: string, default None
+        Optional attribute name of a unique feature identifier. 
     """
 
     _view_name = Unicode("LeafletVectorTileLayerView").tag(sync=True)
@@ -1130,6 +1132,7 @@ class VectorTileLayer(Layer):
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     renderer_factory = Unicode('svg').tag(sync=True, o=True)
+    get_feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1111,6 +1111,8 @@ class VectorTileLayer(Layer):
     visible: boolean, default True
         Whether the layer is visible or not.
     renderer_factory: rendererFactory option ('svg' or 'canvas') for L.VectorGrid, default 'svg'
+    interactive: boolean, default False
+        Whether the layer is interactive or not.
     """
 
     _view_name = Unicode("LeafletVectorTileLayerView").tag(sync=True)
@@ -1120,8 +1122,9 @@ class VectorTileLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
 
     vector_tile_layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
-    opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True)
-    visible = Bool(True).tag(sync=True)
+    opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True,o=True)
+    visible = Bool(True).tag(sync=True, o=True)
+    interactive = Bool(False).tag(sync=True, o=True)
     min_zoom = Int(0).tag(sync=True, o=True)
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1125,6 +1125,7 @@ class VectorTileLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
 
     layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
+    vector_tile_layer_styles = Union([Dict(), Unicode()], allow_none=True, default_value=None)
     opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True,o=True)
     visible = Bool(True).tag(sync=True, o=True)
     interactive = Bool(False).tag(sync=True, o=True)
@@ -1135,6 +1136,13 @@ class VectorTileLayer(Layer):
     renderer = Unicode('svg').tag(sync=True, o=True)
     feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
     feature_style = Dict().tag(sync=True)
+
+    def __init__(self, **kwargs):
+        super(VectorTileLayer, self).__init__(**kwargs)
+        # Backwards compatibility: allow vector_tile_layer_styles as input:
+        vtl_style = getattr(self, "vector_tile_layer_styles")
+        if(vtl_style):
+            self.layer_styles = vtl_style
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1110,7 +1110,7 @@ class VectorTileLayer(Layer):
         Opacity of the layer between 0. (fully transparent) and 1. (fully opaque).
     visible: boolean, default True
         Whether the layer is visible or not.
-    renderer_factory: string, default 'svg'
+    renderer: string, default 'svg'
         Engine for rendering VectorTileLayers; either 'canvas' or 'svg'. Use 'svg' for interactive layers.
     interactive: boolean, default False
         Whether the layer is interactive or not.
@@ -1132,7 +1132,7 @@ class VectorTileLayer(Layer):
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
-    renderer_factory = Unicode('svg').tag(sync=True, o=True)
+    renderer = Unicode('svg').tag(sync=True, o=True)
     get_feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
     feature_style = Dict().tag(sync=True)
 

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1125,7 +1125,6 @@ class VectorTileLayer(Layer):
     attribution = Unicode().tag(sync=True, o=True)
 
     layer_styles = Union([Dict(), Unicode()]).tag(sync=True, o=True)
-    vector_tile_layer_styles = Union([Dict(), Unicode()], allow_none=True, default_value=None)
     opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True,o=True)
     visible = Bool(True).tag(sync=True, o=True)
     interactive = Bool(False).tag(sync=True, o=True)
@@ -1137,12 +1136,22 @@ class VectorTileLayer(Layer):
     feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
     feature_style = Dict().tag(sync=True)
 
+    # Backwards compatibility: allow vector_tile_layer_styles as input:
+    @property
+    def vector_tile_layer_styles(self):
+        return self.layer_styles
+
+    @vector_tile_layer_styles.setter
+    def vector_tile_layer_styles(self, value):
+        self.layer_styles = value     
+
     def __init__(self, **kwargs):
         super(VectorTileLayer, self).__init__(**kwargs)
         # Backwards compatibility: allow vector_tile_layer_styles as input:
-        vtl_style = getattr(self, "vector_tile_layer_styles")
-        if(vtl_style):
-            self.layer_styles = vtl_style
+        if "vector_tile_layer_styles" in kwargs:
+            vtl_style = kwargs["vector_tile_layer_styles"]
+            if(vtl_style):
+                self.layer_styles = vtl_style
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1110,6 +1110,7 @@ class VectorTileLayer(Layer):
         Opacity of the layer between 0. (fully transparent) and 1. (fully opaque).
     visible: boolean, default True
         Whether the layer is visible or not.
+    renderer_factory: rendererFactory option ('svg' or 'canvas') for L.VectorGrid, default 'svg'
     """
 
     _view_name = Unicode("LeafletVectorTileLayerView").tag(sync=True)
@@ -1125,6 +1126,7 @@ class VectorTileLayer(Layer):
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
+    renderer_factory = Unicode('svg').tag(sync=True, o=True)
 
     def redraw(self):
         """Force redrawing the tiles.

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -1134,6 +1134,7 @@ class VectorTileLayer(Layer):
     max_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)
     renderer_factory = Unicode('svg').tag(sync=True, o=True)
     get_feature_id = Unicode(allow_none=True, default_value=None).tag(sync=True, o=True)
+    feature_style = Dict().tag(sync=True)
 
     def redraw(self):
         """Force redrawing the tiles.
@@ -1157,10 +1158,7 @@ class VectorTileLayer(Layer):
         layer_styles: dict
             Style to apply to the feature
         """
-        self.send({"msg": 
-                   {"setFeatureStyle":
-                    {"id":id, "layerStyle":layer_style}}
-                })
+        self.feature_style = {"id": id, "layerStyle": layer_style, "reset": False}
 
     def reset_feature_style(self, id:Int):
         """Reset feature style
@@ -1172,9 +1170,7 @@ class VectorTileLayer(Layer):
         id: int
             The unique identifier for the feature to re-symbolize
         """
-        self.send({"msg": {"resetFeatureStyle":{"id":id}}})
-
-
+        self.feature_style = {"id": id, "reset": True}
 
 class PMTilesLayer(Layer):
     """PMTilesLayer class, with Layer as parent class.

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -67,6 +67,19 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
 
     this.obj = L.vectorGrid.protobuf(this.model.get('url'), options);
     this.model.on('msg:custom', this.handle_message.bind(this));
+
+    this.obj.on(
+      'click mouseover mouseout' as any,
+      (event: LeafletMouseEvent) => {
+        this.send({
+          event: 'interaction',
+          type: event.type,
+          coordinates: [event.latlng.lat, event.latlng.lng],
+          properties: event.propagatedFrom.properties,
+          options: event.propagatedFrom.options,
+        });
+      }
+    );
   }
 
   model_events() {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -68,6 +68,19 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     this.obj = L.vectorGrid.protobuf(this.model.get('url'), options);
     this.model.on('msg:custom', this.handle_message.bind(this));
 
+    this.model.on('change:feature_style', () => {
+      const feature_style = this.model.get('feature_style');
+      const reset = feature_style['reset'];
+      if (reset) {
+        this.obj.resetFeatureStyle(feature_style['id']);
+      } else {
+        this.obj.setFeatureStyle(
+          feature_style['id'],
+          feature_style['layerStyle']
+        );
+      }
+    });
+
     this.obj.on(
       'click mouseover mouseout' as any,
       (event: LeafletMouseEvent) => {
@@ -101,20 +114,9 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     });
   }
 
-  handle_message(content: { msg: any }) {
-    if (typeof content.msg === 'string') {
-      if (content.msg == 'redraw') {
-        this.obj.redraw();
-      }
-    } else {
-      if ('setFeatureStyle' in content.msg) {
-        let options = content.msg.setFeatureStyle;
-        this.obj.setFeatureStyle(options.id, options.layerStyle);
-      }
-      if ('resetFeatureStyle' in content.msg) {
-        let options = content.msg.resetFeatureStyle;
-        this.obj.resetFeatureStyle(options.id);
-      }
+  handle_message(content: { msg: string }) {
+    if (content.msg == 'redraw') {
+      this.obj.redraw();
     }
   }
 }

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -20,6 +20,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       interactive: true,
       visible: true,
       opacity: 1.0,
+      renderer_factory: 'svg',
     };
   }
 }
@@ -31,7 +32,12 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     let options = {
       ...this.get_options(),
     };
-    options['rendererFactory'] = L.canvas.tile;
+    let r: any = options['rendererFactory'];
+    if (r === 'canvas') {
+      options['rendererFactory'] = L.canvas.tile;
+    } else {
+      options['rendererFactory'] = L.svg.tile;
+    }
 
     let x: any = options['vectorTileLayerStyles'];
     if (typeof x === 'string') {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -21,6 +21,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       visible: true,
       opacity: 1.0,
       renderer_factory: 'svg',
+      get_feature_id: null
     };
   }
 }
@@ -32,7 +33,16 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     let options = {
       ...this.get_options(),
     };
+
+    if ('getFeatureId' in options) {
+      let idVar = options['getFeatureId'];
+      options['getFeatureId'] = function (feat: any) {
+        return feat.properties[idVar];
+      };
+    }
+
     let r: any = options['rendererFactory'];
+
     if (r === 'canvas') {
       options['rendererFactory'] = L.canvas.tile;
     } else {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -17,7 +17,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       max_zoom: 18,
       min_native_zoom: null,
       max_native_zoom: null,
-      interactive: true,
+      interactive: false,
       visible: true,
       opacity: 1.0,
       renderer_factory: 'svg',

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -49,19 +49,22 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
       options['rendererFactory'] = L.svg.tile;
     }
 
-    let x: any = options['vectorTileLayerStyles'];
-    if (typeof x === 'string') {
-      try {
-        let blobCode = `const jsStyle=${x}; export { jsStyle };`;
+    if ('layerStyles' in options) {
+      let x: any = options['layerStyles'];
+      options['vectorTileLayerStyles'] = x;
+      if (typeof x === 'string') {
+        try {
+          let blobCode = `const jsStyle=${x}; export { jsStyle };`;
 
-        const blob = new Blob([blobCode], { type: 'text/javascript' });
-        const url = URL.createObjectURL(blob);
-        const module = await import(/* webpackIgnore: true*/ url);
-        const jsStyle = module.jsStyle;
+          const blob = new Blob([blobCode], { type: 'text/javascript' });
+          const url = URL.createObjectURL(blob);
+          const module = await import(/* webpackIgnore: true*/ url);
+          const jsStyle = module.jsStyle;
 
-        options['vectorTileLayerStyles'] = jsStyle;
-      } catch (error) {
-        options['vectorTileLayerStyles'] = {};
+          options['vectorTileLayerStyles'] = jsStyle;
+        } catch (error) {
+          options['vectorTileLayerStyles'] = {};
+        }
       }
     }
 

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { VectorGrid } from 'leaflet';
+import { LeafletMouseEvent, VectorGrid } from 'leaflet';
 import L from '../leaflet';
 import { LeafletLayerModel, LeafletLayerView } from './Layer';
 
@@ -21,7 +21,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       visible: true,
       opacity: 1.0,
       renderer_factory: 'svg',
-      get_feature_id: null
+      get_feature_id: null,
     };
   }
 }
@@ -101,9 +101,20 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     });
   }
 
-  handle_message(content: { msg: string }) {
-    if (content.msg == 'redraw') {
-      this.obj.redraw();
+  handle_message(content: { msg: any }) {
+    if (typeof content.msg === 'string') {
+      if (content.msg == 'redraw') {
+        this.obj.redraw();
+      }
+    } else {
+      if ('setFeatureStyle' in content.msg) {
+        let options = content.msg.setFeatureStyle;
+        this.obj.setFeatureStyle(options.id, options.layerStyle);
+      }
+      if ('resetFeatureStyle' in content.msg) {
+        let options = content.msg.resetFeatureStyle;
+        this.obj.resetFeatureStyle(options.id);
+      }
     }
   }
 }

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -20,7 +20,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       interactive: false,
       visible: true,
       opacity: 1.0,
-      renderer_factory: 'svg',
+      rendererFactory: L.svg.tile,
       get_feature_id: null,
     };
   }
@@ -41,12 +41,13 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
       };
     }
 
-    let r: any = options['rendererFactory'];
-
-    if (r === 'canvas') {
-      options['rendererFactory'] = L.canvas.tile;
-    } else {
-      options['rendererFactory'] = L.svg.tile;
+    if ('renderer' in options) {
+      let r: any = options['renderer'];
+      if (r === 'canvas') {
+        options['rendererFactory'] = L.canvas.tile;
+      } else {
+        options['rendererFactory'] = L.svg.tile;
+      }
     }
 
     if ('layerStyles' in options) {

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -68,6 +68,10 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
     this.obj = L.vectorGrid.protobuf(this.model.get('url'), options);
     this.model.on('msg:custom', this.handle_message.bind(this));
 
+    if (this.model.get('visible') == false) {
+      this.obj.setOpacity(0);
+    }
+
     this.model.on('change:feature_style', () => {
       const feature_style = this.model.get('feature_style');
       const reset = feature_style['reset'];

--- a/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/VectorTileLayer.ts
@@ -21,7 +21,7 @@ export class LeafletVectorTileLayerModel extends LeafletLayerModel {
       visible: true,
       opacity: 1.0,
       rendererFactory: L.svg.tile,
-      get_feature_id: null,
+      getFeatureId: null,
     };
   }
 }
@@ -34,8 +34,8 @@ export class LeafletVectorTileLayerView extends LeafletLayerView {
       ...this.get_options(),
     };
 
-    if ('getFeatureId' in options) {
-      let idVar = options['getFeatureId'];
+    if ('featureId' in options) {
+      let idVar = options['featureId'];
       options['getFeatureId'] = function (feat: any) {
         return feat.properties[idVar];
       };


### PR DESCRIPTION
## Renderer factory

Vector tile layers can be [rendered](https://leaflet.github.io/Leaflet.VectorGrid/vectorgrid-api-docs.html#svg-vs-canvas) using either `L.canvas.tile` or `L.svg.tile`. Currently, only the canvas option is implemented in ipyleaflet and it's not doing a great job at higher levels of zoom, see for example #1095. 

Here a new `renderer` option was added to `VectorTileLayer`, which can be either `svg` or `canvas`, with the new default being `svg`. 

Here's an example using the `ms-buildings` from Microsoft Planetary Computer, with the new default (svg):

```python
import ipyleaflet
m = ipyleaflet.Map(center=(41.91867,-88.10602), zoom=15)
url = 'https://planetarycomputer.microsoft.com/api/data/v1/vector/collections/ms-buildings/tilesets/global-footprints/tiles/{z}/{x}/{y}'
layer = ipyleaflet.VectorTileLayer(
    url=url, 
    attribution='Microsoft', 
    max_native_zoom=13,
    max_zoom=20,
    vector_tile_layer_styles={"bingmlbuildings":{
        "fill":True,
        "weight":0.5
    }},    
)
m.add(layer)
m
```

<img src="https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/6e40384a-c8a1-4b69-8dcf-8999b00d56a1" width="400">

And here's how it renders using `renderer='canvas'`:

<img src="https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/f6a76134-1c72-4306-a987-cda40595a8ac" width="400">

## Interactivity

A new `interactive` option was added with `False` as default, which enables the user to add listeners to the layer, which include information about the feature. Note that the default `renderer='svg'` option should be used for interactivity. For example:

```python
m = ipyleaflet.Map()
layer = ipyleaflet.VectorTileLayer(
    url=url_data,  # My vector tile layer 
    interactive=True,  # New interactive option 
    max_native_zoom=13,
    max_zoom=20,
    renderer='svg', # New renderer option. Defaults to 'svg'
    layer_styles=jStyles,   # javascript function given as a string
    feature_id = 'label', # New feature_id option. Here, 'label' is the name of the (numeric) 
    # attribute in my layer that uniquely identifies each feature (see below for more information)
)
m.add(layer)

def handle_click(**kwargs):    
    if ("properties" in kwargs):
        properties = kwargs["properties"]
        options = kwargs["options"]
        print(properties)
        print(options)

layer.on_click(handle_click)  

m
```

<img src="https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/4dcb7b20-657e-4488-8491-2a0cd16815c6" width="400">


### `feature_id`

This is an optional attribute that is used to construct a simple javascript function to uniquely identify a feature. This is required if you will be updating feature styles through the new `set_feature_style` and `reset_feature_style` methods. The javascript function is of the form:

```js
function (feat: any) {return feat.properties[idVar];}
```

where `feat` is the feature, and `idVar` is the name of the (numeric) attribute in the layer to identify a feature. Note that features with the same id will be treated as one when changing style (see the original `getFeatureId` [documentation here](https://leaflet.github.io/Leaflet.VectorGrid/vectorgrid-api-docs.html#updating-styles)).

### Updating styles

Two new methods for `VectorTileLayer` were added: `set_feature_style` and `reset_feature_style`. The first one is used to update the style for an individual feature, which is useful for highlighting a feature (e.g., on click or mouseover), while the second one is useful for resetting the style to the default (e.g. to clear the highlight). 

### Example

Here's a motivating example that demonstrates all of the new features. 

```python
m = ipyleaflet.Map()
layer = ipyleaflet.VectorTileLayer(
    url=url_data,  # My vector tile layer 
    interactive=True,  # New interactive option 
    max_native_zoom=13,
    max_zoom=20,
    renderer='svg', # New renderer option. Defaults to 'svg'
    layer_styles=jStyles,   # javascript function given as a string
    feature_id = 'label', # New feature_id option. Here, 'label' is the name of the (numeric) 
    # attribute in my layer that uniquely identifies each feature.
)
m.add(layer)

info_title = "<h4>Field info</h4>"
info_default_value = "Hover over a field" 

info_widget = widgets.HTML(value=info_title + info_default_value)

highlight_style = {
                "weight": 5,
                "color": '#666',
                "dashArray": '',
                "fillOpacity": 0.7,
                "fill": True 
                }

def highlight_feature(**kwargs):    
    if ("properties" in kwargs):
        properties = kwargs["properties"]
        options = kwargs["options"]
        feature_id = properties["label"]
        fill_color = options["fillColor"]
        highlight_style["fillColor"] = fill_color
        layer.set_feature_style(
            id=feature_id,
            layer_style=highlight_style,
        )
        info_html = info_title
        for k,v in properties.items():
            info_html += "<b>"+ k + "</b>" + ": " + str(v) + "<br />"
        info_widget.value = info_html

def clear_highlight(**kwargs):
    if layer.feature_style: 
        layer.reset_feature_style(layer.feature_style["id"])
        info_widget.value = info_title + info_default_value
        
layer.on_mouseover(highlight_feature)
layer.on_mouseout(clear_highlight)

widget_control = ipyleaflet.WidgetControl(widget=info_widget, position='topright')
m.add(widget_control)

m
```

<img src="https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/8150df70-0493-4cb2-a603-57ef2ac36353" width="600">
