### PR TITLE
Add on_zoom

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -3171,13 +3171,19 @@ class Map(DOMWidget, InteractMixin):
 
     # Event handling
     _interaction_callbacks = Instance(CallbackDispatcher, ())
+    _zoom_callbacks = Instance(CallbackDispatcher, ())
 
     def _handle_leaflet_event(self, _, content, buffers):
         if content.get("event", "") == "interaction":
             self._interaction_callbacks(**content)
+        if content.get("event", "") == "zoom":
+            self._zoom_callbacks(**content)
 
     def on_interaction(self, callback, remove=False):
         self._interaction_callbacks.register_callback(callback, remove=remove)
+
+    def on_zoom(self, callback, remove=False):
+        self._zoom_callbacks.register_callback(callback, remove=remove)
 
     def fit_bounds(self, bounds):
         """Sets a map view that contains the given geographical bounds

--- a/python/jupyter_leaflet/src/Map.ts
+++ b/python/jupyter_leaflet/src/Map.ts
@@ -336,6 +336,10 @@ export class LeafletMapView extends LeafletDOMWidgetView {
         const z = e.target.getZoom();
         this.model.set('zoom', z);
         this.dirty = false;
+        this.send({
+          event: 'zoom',
+          zoom: z,
+        });
       }
       this.model.update_bounds().then(() => {
         this.touch();


### PR DESCRIPTION
This new `on_zoom` feature is useful for implementing zoom-dependent logic, e.g. adding or removing components to the map based on zoom level. 

For example:

```python
def handle_zoom(**kwargs):
    z = kwargs["zoom"]
    legend_on_map = legend_control.model_id in m._control_ids
    if (z>9):
        if not legend_on_map:
            m.add(legend_control)
    else:
        if legend_on_map:
            m.remove(legend_control)

m.on_zoom(handle_zoom)
```

where `legend_control` is a control that I want shown only on zoom 10 or above:

<img src="https://github.com/jupyter-widgets/ipyleaflet/assets/14804652/b1469db4-e76b-49d5-bf84-c21313a12bee" width="400">



