### PR TITLE
Make Leaflet-Geoman ignore created layers by default

### DIFF
--- a/docs/controls/geoman_draw_control.rst
+++ b/docs/controls/geoman_draw_control.rst
@@ -25,11 +25,14 @@ Additionally, there are modes that allow editing of previously drawn shapes:
 To have a drawing tool active on the map, pass it a non-empty dictionary with the desired options, see
 `geoman documentation <https://www.geoman.io/docs/modes/draw-mode#customize-style>`_ for details.
 
+By default, editing is disabled for shapes created programmatically as described in the :ref:`layers-section` page.
+However, adding ``pm_ignore=False`` to shapes allows them to be modified using the control.
+
 Example
 -------
 .. jupyter-execute::
 
-    from ipyleaflet import Map, GeomanDrawControl
+    from ipyleaflet import Map, GeomanDrawControl, Circle
 
     m = Map(center=(50, 354), zoom=5)
 
@@ -64,6 +67,12 @@ Example
     }
 
     m.add(draw_control)
+
+    circle = Circle(location=(50, 352), radius=100000, color="blue")
+    m.add(circle)
+
+    editable_circle = Circle(location=(50, 356), radius=100000, pm_ignore=False, color="red")
+    m.add(editable_circle)
 
     m
 

--- a/docs/controls/geoman_draw_control.rst
+++ b/docs/controls/geoman_draw_control.rst
@@ -1,10 +1,11 @@
 Geoman Draw Control
-============
+===================
 
-``GeomanDrawControl`` allows one to draw various shapes on the map. 
+``GeomanDrawControl`` allows one to draw various shapes on the map.
 The drawing functionality on the front-end is provided by `geoman <https://geoman.io/>`_.
 
 The following shapes are supported:
+
 - marker
 - circlemarker
 - circle

--- a/docs/controls/geoman_draw_control.rst
+++ b/docs/controls/geoman_draw_control.rst
@@ -51,13 +51,14 @@ Example
             "fillOpacity": 1.0
         }
     }
-    draw_control.circlemarker = {
+    draw_control.circle = {
         "pathOptions": {
             "fillColor": "#efed69",
             "color": "#efed69",
             "fillOpacity": 0.62
         }
     }
+    draw_control.circlemarker = {}
     draw_control.rectangle = {
         "pathOptions": {
             "fillColor": "#fca45d",

--- a/docs/layers/index.rst
+++ b/docs/layers/index.rst
@@ -1,3 +1,5 @@
+.. _layers-section:
+
 Layers
 ======
 

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -171,6 +171,8 @@ class Layer(Widget, InteractMixin):
         Interactive widget that will be shown in a Popup when clicking on the layer.
     pane: string
         Name of the pane to use for the layer.
+    pm_ignore: boolean
+        Make Leaflet-Geoman ignore the layer, so it cannot modify it.
     """
 
     _view_name = Unicode("LeafletLayerView").tag(sync=True)
@@ -194,6 +196,8 @@ class Layer(Widget, InteractMixin):
 
     options = List(trait=Unicode()).tag(sync=True)
     subitems = Tuple().tag(trait=Instance(Widget), sync=True, **widget_serialization)
+
+    pm_ignore = Bool(True).tag(sync=True, o=True)
 
     @validate("subitems")
     def _validate_subitems(self, proposal):


### PR DESCRIPTION
Fixes #1215, see discussion therein.

The possible usage of `pm_ignore=False` is now also included in the in 'Geoman Draw Control' documentation page (with some minor adjustments to existing content)