### PR TITLE
Add event coordinates to GeoJSON message

### DIFF
--- a/python/jupyter_leaflet/src/layers/GeoJSON.ts
+++ b/python/jupyter_leaflet/src/layers/GeoJSON.ts
@@ -57,6 +57,7 @@ export class LeafletGeoJSONView extends LeafletFeatureGroupView {
             feature: feature,
             properties: feature.properties,
             id: feature.id,
+            coordinates: [e.latlng.lat, e.latlng.lng],
           });
         };
         layer.on({


### PR DESCRIPTION
This pull request adds event coordinates to the message sent on click and mouseover on `GeoJSON.ts`. 

For example, here we can open a popup on the feature clicked by the user (#1227):

![ipyleaflet-popup-click-location](https://github.com/user-attachments/assets/d65f3fc6-1e4f-4185-a594-e8725bb4e7dc)

```python
from ipyleaflet import Map, GeoJSON, Popup
from ipywidgets import HTML

# Create a map centered at a specific location
m = Map(center=(51.55, -0.09), zoom=10)

# Example GeoJSON data with two polygons
geojson_data = {
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "properties": {
                "name": "Polygon A",
                "popup_content": "This is Polygon A."
            },
            "geometry": {
                "type": "Polygon",
                "coordinates": [[
                    [-0.1, 51.5],
                    [-0.1, 51.6],
                    [-0.05, 51.6],
                    [-0.05, 51.5],
                    [-0.1, 51.5]
                ]]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "name": "Polygon B",
                "popup_content": "This is Polygon B."
            },
            "geometry": {
                "type": "Polygon",
                "coordinates": [[
                    [-0.08, 51.48],
                    [-0.08, 51.52],
                    [-0.03, 51.52],
                    [-0.03, 51.48],
                    [-0.08, 51.48]
                ]]
            }
        }
    ]
}

# Create a GeoJSON layer
geojson_layer = GeoJSON(data=geojson_data)

# Popup
popup = Popup(
    close_button=True,
    auto_close=False,
    auto_pan=False,
    close_on_escape_key=False
)

def on_click_handler(**kwargs):
    properties = kwargs["properties"]
    popup.child = HTML(properties["popup_content"])
    popup.location = kwargs["coordinates"]  # This is what this PR provides.
    popup.open_popup()

geojson_layer.on_click(on_click_handler)

m.add(popup)
m.add(geojson_layer)
```