### PR TITLE
fix: geojson layers pmIgnore

### DIFF
--- a/python/jupyter_leaflet/src/layers/GeoJSON.ts
+++ b/python/jupyter_leaflet/src/layers/GeoJSON.ts
@@ -63,6 +63,14 @@ export class LeafletGeoJSONView extends LeafletFeatureGroupView {
             coordinates: [e.latlng.lat, e.latlng.lng],
           });
         };
+        const pmIgnore = this.model.get('pm_ignore');
+        if (pmIgnore !== undefined) {
+          (layer as any).pmIgnore = pmIgnore;
+            if (pmIgnore && layer.pm) {
+              layer.pm.disable();
+              delete (layer as any).pm;
+            }
+        }
         layer.on({
           mouseover: mouseevent,
           click: mouseevent,

--- a/python/jupyter_leaflet/src/layers/GeoJSON.ts
+++ b/python/jupyter_leaflet/src/layers/GeoJSON.ts
@@ -66,10 +66,10 @@ export class LeafletGeoJSONView extends LeafletFeatureGroupView {
         const pmIgnore = this.model.get('pm_ignore');
         if (pmIgnore !== undefined) {
           (layer as any).pmIgnore = pmIgnore;
-            if (pmIgnore && layer.pm) {
-              layer.pm.disable();
-              delete (layer as any).pm;
-            }
+          if (pmIgnore && layer.pm) {
+            layer.pm.disable();
+            delete (layer as any).pm;
+          }
         }
         layer.on({
           mouseover: mouseevent,


### PR DESCRIPTION
Similar to #1249 , this PR updates jupyter_leaflet so that individual layers created by the LeafletGeoJSONModel get the proper `pmIgnore` option -- and disable the `pm` if it's already attached. This fixes the issue that Geoman is able to edit GeoJson layers, even though they inherit the `pm_ignore` from the base Layer class. 