### PR TITLE
CI: check comment author association instead of issue author

### DIFF
--- a/.github/workflows/update_galata_references.yml
+++ b/.github/workflows/update_galata_references.yml
@@ -16,9 +16,9 @@ jobs:
   update-snapshots:
     if: >
       (
-        github.event.issue.author_association == 'OWNER' ||
-        github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'MEMBER'
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER'
       ) && github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR updates the conditional logic in the `update-snapshots` GitHub Actions workflow to correctly validate the **comment author's** association with the repository, instead of the **issue/PR author's**.