### PR TITLE
Update deprecated subdomains for tile.openstreetmap.org

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -662,7 +662,7 @@ class TileLayer(RasterLayer):
 
     Attributes
     ----------
-    url: string, default "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    url: string, default "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
         Url to the tiles service.
     min_zoom: int, default 0
         The minimum zoom level down to which this layer will be displayed (inclusive).
@@ -697,7 +697,7 @@ class TileLayer(RasterLayer):
     _model_name = Unicode("LeafletTileLayerModel").tag(sync=True)
 
     bottom = Bool(True).tag(sync=True)
-    url = Unicode("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").tag(sync=True)
+    url = Unicode("https://tile.openstreetmap.org/{z}/{x}/{y}.png").tag(sync=True)
     min_zoom = Int(0).tag(sync=True, o=True)
     max_zoom = Int(18).tag(sync=True, o=True)
     min_native_zoom = Int(default_value=None, allow_none=True).tag(sync=True, o=True)

--- a/python/jupyter_leaflet/src/layers/TileLayer.ts
+++ b/python/jupyter_leaflet/src/layers/TileLayer.ts
@@ -13,7 +13,7 @@ export class LeafletTileLayerModel extends LeafletRasterLayerModel {
       _view_name: 'LeafletTileLayerView',
       _model_name: 'LeafletTileLayerModel',
       bottom: true,
-      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
       min_zoom: 0,
       max_zoom: 18,
       min_native_zoom: null,


### PR DESCRIPTION
Supersedes #1132 while resolving merge conflicts