### PR TITLE
fix `examples/KML.ipynb`

### DIFF
--- a/examples/KML.ipynb
+++ b/examples/KML.ipynb
@@ -6,7 +6,8 @@
    "source": [
     "You will need to install the below packages:\n",
     "- `ipyleaflet`\n",
-    "- `geopandas`"
+    "- `geopandas`\n",
+    "- `fiona`"
    ]
   },
   {
@@ -16,8 +17,8 @@
    "outputs": [],
    "source": [
     "from ipyleaflet import Map, GeoData\n",
-    "import geopandas\n",
-    "import geodatasets as gpd"
+    "import geopandas as gpd\n",
+    "import fiona"
    ]
   },
   {
@@ -30,7 +31,7 @@
     "\n",
     "m = Map(center=[41.8781, -87.6298], zoom=4)\n",
     "\n",
-    "gpd.io.file.fiona.drvsupport.supported_drivers[\"KML\"] = \"rw\"\n",
+    "fiona.drvsupport.supported_drivers[\"KML\"] = \"rw\"\n",
     "us_states = gpd.read_file(\"data/us-states.kml\", driver=\"KML\")\n",
     "\n",
     "geo_data = GeoData(\n",
@@ -48,11 +49,18 @@
     "m.add(geo_data)\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -66,7 +74,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fix examples/KML.ipynb because Recent versions of geopandas import fiona dynamically, and gpd.io.file.fiona is initially None.

Supersedes #1141 and resolves merge conflicts


![28595](https://github.com/user-attachments/assets/85492fed-781a-4312-9a2e-778890cc4f9d)
