### PR TITLE
feat: tooltips

### DIFF
--- a/docs/layers/tooltip.rst
+++ b/docs/layers/tooltip.rst
@@ -1,0 +1,70 @@
+Tooltip
+=====
+
+Example
+-------
+
+.. jupyter-execute::
+
+    from ipyleaflet import Map, Tooltip, Marker, Polygon, Circle
+
+    m = Map(center=(51.505,-0.09), zoom=13)
+
+    standalone_tooltip = Tooltip(
+        location=[51.5, -0.09], 
+        content="Hello world!<br />This is a nice tooltip.",
+        offset=[-30,50], # Offset in pixels
+        permanent=False,  # The default is False, in which case you can remove the tooltip by clicking on it. 
+        direction='bottom', # Default is 'auto'
+    )
+
+    marker_tooltip = Tooltip(
+        content="I'm a marker tooltip! 👋<br>Appears on hover.",
+    )
+
+    marker = Marker(
+        location=[51.5, -0.09], 
+        draggable=False,
+        tooltip=marker_tooltip,
+    )
+
+    polygon = Polygon(
+        locations= [
+            [51.509, -0.08],
+            [51.503, -0.06],
+            [51.51, -0.047]
+    ])
+
+    polygon_tooltip = Tooltip(
+        content = "Polygon's Permanent Tooltip 🗺️",
+        permanent = True,
+        direction = 'center', # Centers the tooltip on the polygon   
+    )
+
+    polygon.tooltip = polygon_tooltip
+
+    circle = Circle(
+        location = [51.515, -0.1],
+        radius = 500,
+        color = 'green',
+        fillColor = '#0f3', 
+        fillOpacity = 0.5,
+        tooltip = Tooltip(
+            content = "Sticky Tooltip here! 📍<br>Stays with the mouse.",
+            sticky = True,
+        )
+    )
+
+    m.add(standalone_tooltip)
+    m.add(marker)
+    m.add(polygon)
+    m.add(circle)
+
+    m
+
+
+Attributes and methods
+----------------------
+
+.. autoclass:: ipyleaflet.leaflet.Tooltip
+   :members:

--- a/docs/layers/tooltip.rst
+++ b/docs/layers/tooltip.rst
@@ -14,7 +14,7 @@ Example
         location=[51.5, -0.09], 
         content="Hello world!<br />This is a nice tooltip.",
         offset=[-30,50], # Offset in pixels
-        permanent=False,  # The default is False, in which case you can remove the tooltip by clicking on it. 
+        permanent=False,  # The default is False, in which case you can remove the tooltip by clicking anywhere on the map.
         direction='bottom', # Default is 'auto'
     )
 

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -640,6 +640,39 @@ class Popup(UILayer):
         self.send({"msg": "close"})
 
 
+class Tooltip(UILayer):
+    """Tooltip class.
+
+    Used to display small texts on top of map layers.
+
+    Attributes
+    ----------
+    location: tuple, default None
+        Optional tuple containing the latitude/longitude of the stand-alone tooltip.
+    content: str, default ""
+        The text to show inside the tooltip
+    offset: tuple, default (0, 0)
+        Optional offset of the tooltip position (in pixels).
+    direction: str, default 'auto'
+        Direction where to open the tooltip. 
+        Possible values are: right, left, top, bottom, center, auto. 
+        auto will dynamically switch between right and left according 
+        to the tooltip position on the map.
+    permanent: bool, default False
+        Whether to open the tooltip permanently or only on mouseover.
+    """
+    _view_name = Unicode("LeafletTooltipView").tag(sync=True)
+    _model_name = Unicode("LeafletTooltipModel").tag(sync=True)
+
+    location = List(allow_none=True, default_value=None).tag(sync=True)
+
+    # Options
+    content = Unicode('').tag(sync=True, o=True)
+    offset = List(def_loc).tag(sync=True, o=True)
+    direction=Unicode('auto').tag(sync=True, o=True)
+    permanent = Bool(False).tag(sync=True, o=True)
+
+
 class RasterLayer(Layer):
     """Abstract RasterLayer class.
 

--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -175,6 +175,8 @@ class Layer(Widget, InteractMixin):
         Make Leaflet-Geoman ignore the layer, so it cannot modify it.
     snap_ignore: boolean
         Make Leaflet-Geoman snapping ignore the layer, so it is not used as a snap target when editing.
+    tooltip: Tooltip widget
+        Tooltip widget to bind to the layer.
     """
 
     _view_name = Unicode("LeafletLayerView").tag(sync=True)
@@ -195,6 +197,10 @@ class Layer(Widget, InteractMixin):
     popup_max_width = Int(300).tag(sync=True)
     popup_max_height = Int(default_value=None, allow_none=True).tag(sync=True)
     pane = Unicode("").tag(sync=True)
+
+    tooltip = Instance(Widget, allow_none=True, default_value=None).tag(
+        sync=True, **widget_serialization
+    )
 
     options = List(trait=Unicode()).tag(sync=True)
     subitems = Tuple().tag(trait=Instance(Widget), sync=True, **widget_serialization)
@@ -660,6 +666,9 @@ class Tooltip(UILayer):
         to the tooltip position on the map.
     permanent: bool, default False
         Whether to open the tooltip permanently or only on mouseover.
+    sticky: bool, default False
+        If true, the tooltip will follow the mouse instead of being fixed at the feature center.
+        This option only applies when binding the tooltip to a Layer, not as stand-alone.
     """
     _view_name = Unicode("LeafletTooltipView").tag(sync=True)
     _model_name = Unicode("LeafletTooltipModel").tag(sync=True)
@@ -671,6 +680,7 @@ class Tooltip(UILayer):
     offset = List(def_loc).tag(sync=True, o=True)
     direction=Unicode('auto').tag(sync=True, o=True)
     permanent = Bool(False).tag(sync=True, o=True)
+    sticky = Bool(False).tag(sync=True, o=True)
 
 
 class RasterLayer(Layer):

--- a/python/jupyter_leaflet/src/jupyter-leaflet.ts
+++ b/python/jupyter_leaflet/src/jupyter-leaflet.ts
@@ -27,6 +27,7 @@ export * from './layers/Popup';
 export * from './layers/RasterLayer';
 export * from './layers/Rectangle';
 export * from './layers/TileLayer';
+export * from './layers/Tooltip';
 export * from './layers/VectorLayer';
 export * from './layers/VectorTileLayer';
 export * from './layers/Velocity';

--- a/python/jupyter_leaflet/src/layers/Layer.ts
+++ b/python/jupyter_leaflet/src/layers/Layer.ts
@@ -207,6 +207,9 @@ export class LeafletLayerView extends LeafletWidgetView {
     this.listenTo(this.model, 'change:subitems', () => {
       this.subitem_views.update(this.subitems);
     });
+    this.listenTo(this.model, 'change:tooltip', () => {
+      this.bind_tooltip(this.model.get('tooltip'));
+    });
   }
 
   remove() {

--- a/python/jupyter_leaflet/src/layers/Tooltip.ts
+++ b/python/jupyter_leaflet/src/layers/Tooltip.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { WidgetView } from '@jupyter-widgets/base';
+import { Tooltip, TooltipOptions } from 'leaflet';
+import L from '../leaflet';
+import {
+  ILeafletLayerModel,
+  LeafletUILayerModel,
+  LeafletUILayerView,
+} from './Layer';
+
+interface ILeafletTooltipModel extends ILeafletLayerModel {
+  _view_name: string;
+  _model_name: string;
+  location: number[] | null;
+}
+
+export class LeafletTooltipModel extends LeafletUILayerModel {
+  defaults(): ILeafletTooltipModel {
+    return {
+      ...super.defaults(),
+      _view_name: 'LeafletMarkerView',
+      _model_name: 'LeafletMarkerModel',
+      location: null,
+    };
+  }
+}
+
+export class LeafletTooltipView extends LeafletUILayerView {
+  obj: Tooltip;
+
+  initialize(
+    parameters: WidgetView.IInitializeParameters<LeafletTooltipModel>
+  ) {
+    super.initialize(parameters);
+  }
+
+  create_obj() {
+    if (this.model.get('location')) {
+      // Stand-alone tooltip
+      this.obj = (L.tooltip as any)(
+        this.model.get('location'),
+        this.get_options() as TooltipOptions
+      );
+    } else {
+      // TODO: Tooltip to be bound to another layer
+      this.obj = L.tooltip(this.get_options() as TooltipOptions);
+    }
+  }
+
+  model_events() {
+    super.model_events();
+  }
+}

--- a/python/jupyter_leaflet/src/layers/Tooltip.ts
+++ b/python/jupyter_leaflet/src/layers/Tooltip.ts
@@ -44,7 +44,6 @@ export class LeafletTooltipView extends LeafletUILayerView {
         this.get_options() as TooltipOptions
       );
     } else {
-      // TODO: Tooltip to be bound to another layer
       this.obj = L.tooltip(this.get_options() as TooltipOptions);
     }
   }

--- a/python/jupyter_leaflet/src/layers/Tooltip.ts
+++ b/python/jupyter_leaflet/src/layers/Tooltip.ts
@@ -51,5 +51,17 @@ export class LeafletTooltipView extends LeafletUILayerView {
 
   model_events() {
     super.model_events();
+    this.listenTo(this.model, 'change:location', () => {
+      if (this.model.get('location')) {
+        this.obj.setLatLng(this.model.get('location'));
+        this.send({
+          event: 'move',
+          location: this.model.get('location'),
+        });
+      }
+    });
+    this.listenTo(this.model, 'change:content', () => {
+      this.obj.setContent(this.model.get('content'));
+    });
   }
 }


### PR DESCRIPTION
This adds ipyleaflet.Tooltip in order to use [leaflet tooltips](https://leafletjs.com/reference.html#tooltip).

The user can create a "standalone" tooltip at a given location, or bind a Tooltip widget to a Layer, as demonstrated below:

![ipyleaflet-tooltip-demo](https://github.com/user-attachments/assets/faf35509-b352-4089-82c1-a338a464291a)

@martinRenou  @arjxn-py  or any other maintainer, please review =) 