### PR TITLE
fix `attribution_control` being added twice for #1114

### DIFF
--- a/python/ipyleaflet/ipyleaflet/leaflet.py
+++ b/python/ipyleaflet/ipyleaflet/leaflet.py
@@ -2985,12 +2985,6 @@ class Map(DOMWidget, InteractMixin):
             self.zoom_control_instance = ZoomControl()
             self.add(self.zoom_control_instance)
 
-        if self.attribution_control:
-            self.attribution_control_instance = AttributionControl(
-                position="bottomright"
-            )
-            self.add(self.attribution_control_instance)
-
     @observe("zoom_control")
     def observe_zoom_control(self, change):
         if change["new"]:


### PR DESCRIPTION
observing `attribution_control` adds an instance of the control. However the control is added earlier in the Map initialization, and so the attributions are added twice as noted in #1114. This removes the earlier addition of the attribution control so that only a single instance is shown.